### PR TITLE
Setup Github Actions for PR Builds

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -1,0 +1,32 @@
+name: Feature
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build_feature:
+    name: Build feature
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        include:
+          - os: ubuntu-latest
+            name: linux
+          - os: macos-latest
+            name: mac
+          - os: windows-latest
+            name: win
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Build binary
+        run: |
+          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+          cmake --build ./build --config Debug

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ SHORTCIRCUIT CRITICAL
 - horizontal slider
 - draggable value slider with typein (like the range boxes)
 - tree view
-- setup azure or actions
 
 - Clean headers everywhere
 - Mouse Hiding


### PR DESCRIPTION
But explicitly do *not* make a binary available since we
don't associate this particular instance with either a licensed
JUCE or a GPL3 program