### PR TITLE
Block Layout following ED's figma

### DIFF
--- a/examples/scxt-wireframes/MainWindow.h
+++ b/examples/scxt-wireframes/MainWindow.h
@@ -1,0 +1,113 @@
+//
+// Created by Paul Walker on 12/26/22.
+//
+
+#ifndef SST_JUCEGUI_MAINWINDOW_H
+#define SST_JUCEGUI_MAINWINDOW_H
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <sst/jucegui/style/StyleSheet.h>
+
+namespace scxt::wireframe
+{
+struct MainWindow : public juce::Component
+{
+    struct DebugRect : public juce::Component
+    {
+        juce::Colour color;
+        std::string label;
+        DebugRect(const juce::Colour &c, const std::string &s) : color(c), label(s) {}
+        void paint(juce::Graphics &g) override
+        {
+            g.fillAll(color);
+            g.setColour(color.contrasting());
+            g.drawText(label, getLocalBounds(), juce::Justification::centred);
+        }
+    };
+
+    static constexpr int headerHeight = 34;
+    static constexpr int sideWidths = 196;
+    static constexpr int edgeDistance = 6;
+
+    static constexpr int envHeight = 160, modHeight = 160, fxHeight = 176;
+    static constexpr int pad = 2;
+
+    std::unique_ptr<juce::Component> header, browser, parts, mainSection, sample, fx[4], mod, mix,
+        eg[2], lfo;
+    MainWindow()
+    {
+        sst::jucegui::style::StyleSheet::initializeStyleSheets([]() {});
+        header = std::make_unique<DebugRect>(juce::Colour(240, 240, 100), "Header");
+        addAndMakeVisible(*header);
+        parts = std::make_unique<DebugRect>(juce::Colour(100, 120, 200), "Parts");
+        addAndMakeVisible(*parts);
+        mainSection = std::make_unique<DebugRect>(juce::Colour(80, 80, 80), "Main");
+        addAndMakeVisible(*mainSection);
+        browser = std::make_unique<DebugRect>(juce::Colour(200, 120, 100), "Browser");
+        addAndMakeVisible(*browser);
+        sample = std::make_unique<DebugRect>(juce::Colour(200, 100, 0), "Sample");
+        addAndMakeVisible(*sample);
+
+        for (int i = 0; i < 4; ++i)
+        {
+            fx[i] = std::make_unique<DebugRect>(juce::Colour(i * 60, 0, (4 - i) * 60),
+                                                "FX" + std::to_string(i));
+            addAndMakeVisible(*(fx[i]));
+        }
+        mod = std::make_unique<DebugRect>(juce::Colour(100, 200, 150), "Mod");
+        addAndMakeVisible(*mod);
+        mix = std::make_unique<DebugRect>(juce::Colour(150, 220, 100), "Mix");
+        addAndMakeVisible(*mix);
+
+        for (int i = 0; i < 2; ++i)
+        {
+            eg[i] = std::make_unique<DebugRect>(juce::Colour(250, 120 + i * 40, 120),
+                                                "EG" + std::to_string(i));
+            addAndMakeVisible(*(eg[i]));
+        }
+        lfo = std::make_unique<DebugRect>(juce::Colour(250, 80, 120), "LFO");
+        addAndMakeVisible(*lfo);
+    }
+    void paint(juce::Graphics &g) override { g.fillAll(juce::Colours::black); }
+    void resized() override { layout(); }
+
+    void layout()
+    {
+        header->setBounds(pad, pad, getWidth() - 2 * pad, headerHeight - 2 * pad);
+        parts->setBounds(pad, headerHeight + pad, sideWidths, getHeight() - headerHeight - 3 * pad);
+        browser->setBounds(getWidth() - sideWidths - pad, headerHeight + pad, sideWidths,
+                           getHeight() - headerHeight - 3 * pad);
+
+        auto mainRect = juce::Rectangle<int>(sideWidths + 3 * pad, headerHeight + pad,
+                                             getWidth() - 2 * sideWidths - 6 * pad,
+                                             getHeight() - headerHeight - 3 * pad);
+        mainSection->setBounds(mainRect);
+
+        auto wavHeight = mainRect.getHeight() - envHeight - modHeight - fxHeight;
+        sample->setBounds(mainRect.withHeight(wavHeight));
+
+        auto fxRect = mainRect.withTrimmedTop(wavHeight).withHeight(fxHeight);
+        auto fw = fxRect.getWidth() * 0.25;
+        auto tfr = fxRect.withWidth(fw);
+        for (int i = 0; i < 4; ++i)
+        {
+            fx[i]->setBounds(tfr);
+            tfr.translate(fw, 0);
+        }
+
+        auto modRect = mainRect.withTrimmedTop(wavHeight + fxHeight).withHeight(modHeight);
+        auto mw = modRect.getWidth() * 0.750;
+        mod->setBounds(modRect.withWidth(mw));
+        auto xw = modRect.getWidth() * 0.250;
+        mix->setBounds(modRect.withWidth(xw).translated(mw, 0));
+
+        auto envRect =
+            mainRect.withTrimmedTop(wavHeight + fxHeight + modHeight).withHeight(envHeight);
+        auto ew = envRect.getWidth() * 0.25;
+        eg[0]->setBounds(envRect.withWidth(ew));
+        eg[1]->setBounds(envRect.withWidth(ew).translated(ew, 0));
+        lfo->setBounds(envRect.withWidth(ew * 2).translated(ew * 2, 0));
+    }
+};
+} // namespace scxt::wireframe
+#endif // SST_JUCEGUI_MAINWINDOW_H

--- a/examples/scxt-wireframes/SCXTWireframesMain.cpp
+++ b/examples/scxt-wireframes/SCXTWireframesMain.cpp
@@ -5,6 +5,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include "sst/jucegui/style/StyleSheet.h"
+#include "MainWindow.h"
 
 struct SCXTWireframesMain : public juce::JUCEApplication
 {
@@ -17,37 +18,6 @@ struct SCXTWireframesMain : public juce::JUCEApplication
     }
     void shutdown() override {}
 
-    struct SCXTWireframeMainComponent : public juce::Component
-    {
-        struct ClosableDW : public juce::DocumentWindow
-        {
-            SCXTWireframeMainComponent *comp{nullptr};
-            ClosableDW(SCXTWireframeMainComponent *c, const juce::String &name,
-                       juce::Colour backgroundColour, int requiredButtons)
-                : comp(c), juce::DocumentWindow(name, backgroundColour, requiredButtons)
-            {
-            }
-            void closeButtonPressed() override { comp->closeWin(this); }
-        };
-
-        SCXTWireframeMainComponent()
-        {
-            sst::jucegui::style::StyleSheet::initializeStyleSheets([]() {});
-        }
-        void paint(juce::Graphics &g) override { g.fillAll(juce::Colours::black); }
-        void resized() override {}
-
-        void closeWin(juce::DocumentWindow *t)
-        {
-            auto q = windows.begin();
-            while (q != windows.end() && q->get() != t)
-                ++q;
-            if (q != windows.end())
-                windows.erase(q);
-        }
-        std::vector<std::unique_ptr<juce::TextButton>> buttons;
-        std::set<std::unique_ptr<juce::DocumentWindow>> windows;
-    };
     class SCXTDemoMainWindow : public juce::DocumentWindow
     {
       public:
@@ -58,10 +28,10 @@ struct SCXTWireframesMain : public juce::JUCEApplication
                                    juce::DocumentWindow::allButtons)
         {
             setUsingNativeTitleBar(true);
-            setResizable(true, false);
-            setResizeLimits(400, 400, 900, 1000);
+            setResizable(true, true);
+            setSize(1186, 810);
 
-            setContentOwned(new SCXTWireframeMainComponent(), false);
+            setContentOwned(new scxt::wireframe::MainWindow(), false);
             setVisible(true);
         }
 


### PR DESCRIPTION
There's now a reasonable imlpementation of the block layout from the SCXT Figma Wireframe. Now to make some widgets look right. Then to port it to the SCXT engine. So just two steps left and we're done.