### PR TITLE
Default value support 

### DIFF
--- a/examples/component-demo/ExampleUtils.h
+++ b/examples/component-demo/ExampleUtils.h
@@ -38,6 +38,7 @@ struct ConcreteCM : sst::jucegui::data::ContinunousModulatable
     std::string getLabel() const override { return label; }
     float value{0};
     float getValue() const override { return value; }
+    float getDefaultValue() const override { return (getMax()-getMin())/2.0; }
     void setValueFromGUI(const float &f) override
     {
         value = f;

--- a/include/sst/jucegui/components/ContinuousParamEditor.h
+++ b/include/sst/jucegui/components/ContinuousParamEditor.h
@@ -48,6 +48,7 @@ struct ContinuousParamEditor : public juce::Component,
     void mouseDown(const juce::MouseEvent &e) override;
     void mouseUp(const juce::MouseEvent &e) override;
     void mouseDrag(const juce::MouseEvent &e) override;
+    void mouseDoubleClick(const juce::MouseEvent &e) override;
     void mouseWheelMove(const juce::MouseEvent &event,
                         const juce::MouseWheelDetails &wheel) override;
 

--- a/include/sst/jucegui/data/Continuous.h
+++ b/include/sst/jucegui/data/Continuous.h
@@ -31,7 +31,7 @@ struct Continuous : public Labeled
     virtual float getValue() const = 0;
     virtual void setValueFromGUI(const float &f) = 0;
     virtual void setValueFromModel(const float &f) = 0;
-
+    virtual float getDefaultValue() const = 0;
     virtual float getValue01() { return (getValue() - getMin()) / (getMax() - getMin()); }
 
     virtual std::string getValueAsStringFor(float f) const { return std::to_string(f); }

--- a/src/sst/jucegui/components/ContinuousParamEditor.cpp
+++ b/src/sst/jucegui/components/ContinuousParamEditor.cpp
@@ -42,6 +42,16 @@ void ContinuousParamEditor::mouseUp(const juce::MouseEvent &e)
         onEndEdit();
     mouseMode = NONE;
 }
+
+void ContinuousParamEditor::mouseDoubleClick(const juce::MouseEvent &e)
+{
+    if (source->isHidden())
+        return;
+    onBeginEdit();
+    source->setValueFromGUI(source->getDefaultValue());
+    onEndEdit();
+}
+
 void ContinuousParamEditor::mouseDrag(const juce::MouseEvent &e)
 {
     if (source->isHidden())


### PR DESCRIPTION
Added support stuff to be able to get the default value of source and use it in mouse double click handler for relevant components. The double click handling might need to be implemented in a more fancy way later as currently whatever the mouse down and mouse up handlers are doing, will also be executed multiple times.