### PR TITLE
Tweaks around enabled and name

### DIFF
--- a/include/sst/jucegui/components/NamedPanel.h
+++ b/include/sst/jucegui/components/NamedPanel.h
@@ -56,6 +56,18 @@ struct NamedPanel : public juce::Component,
         resized();
     }
 
+    virtual void setName(const juce::String &n) override
+    {
+        juce::Component::setName(n);
+        name = n.toStdString();
+        repaint();
+    }
+
+    virtual void enablementChanged() override
+    {
+        repaint();
+    }
+
     bool isTabbed{false};
     std::vector<std::string> tabNames{};
     size_t selectedTab{0};

--- a/src/sst/jucegui/components/NamedPanel.cpp
+++ b/src/sst/jucegui/components/NamedPanel.cpp
@@ -66,15 +66,18 @@ void NamedPanel::paintHeader(juce::Graphics &g)
 
     g.setColour(getColour(Styles::labelrulecol));
     ht = b.withHeight(headerHeight);
+
+    auto showHamburger = isEnabled() && hasHamburger;
+
     auto q = ht.toFloat()
                  .withTrimmedLeft(labelWidth + 4)
                  .translated(0, ht.getHeight() / 2 - 0.5)
                  .withHeight(1)
                  .reduced(4, 0)
-                 .withTrimmedRight(hasHamburger * hamburgerSize);
+                 .withTrimmedRight(showHamburger * hamburgerSize);
     g.fillRect(q);
 
-    if (hasHamburger)
+    if (showHamburger)
     {
         auto hb = getHamburgerRegion();
         auto cx = hb.getCentreX();


### PR DESCRIPTION
enabled enables the hamburger. setName resets the named panel name.