### PR TITLE
Sunday QOL Items

### DIFF
--- a/include/sst/jucegui/components/ContinuousParamEditor.h
+++ b/include/sst/jucegui/components/ContinuousParamEditor.h
@@ -58,6 +58,10 @@ struct ContinuousParamEditor : public juce::Component,
 
     void paint(juce::Graphics &g) override { g.fillAll(juce::Colours::red); }
 
+    // Various enablement and hidden conditions get put here
+    bool processMouseActions();
+
+    // and then queried in these events
     void mouseDown(const juce::MouseEvent &e) override;
     void mouseUp(const juce::MouseEvent &e) override;
     void mouseDrag(const juce::MouseEvent &e) override;

--- a/include/sst/jucegui/components/MultiSwitch.h
+++ b/include/sst/jucegui/components/MultiSwitch.h
@@ -88,7 +88,8 @@ struct MultiSwitch : public juce::Component,
 
     void paint(juce::Graphics &g) override;
 
-    void setElementSize(int i) {
+    void setElementSize(int i)
+    {
         elementSize = i;
         repaint();
     }

--- a/include/sst/jucegui/components/NamedPanel.h
+++ b/include/sst/jucegui/components/NamedPanel.h
@@ -25,14 +25,17 @@
 #include <sst/jucegui/style/StyleAndSettingsConsumer.h>
 #include <sst/jucegui/style/StyleSheet.h>
 #include "BaseStyles.h"
+#include <sst/jucegui/data/Discrete.h>
 
 namespace sst::jucegui::components
 {
+struct ToggleButton;
+
 struct NamedPanel : public juce::Component,
                     public style::StyleConsumer,
                     public style::SettingsConsumer
 {
-    static constexpr int outerMargin = 2, cornerRadius = 2, headerHeight = 20;
+    static constexpr int outerMargin = 2, cornerRadius = 2, headerHeight = 20, togglePad = 3;
 
     struct Styles : BaseStyles
     {
@@ -66,7 +69,13 @@ struct NamedPanel : public juce::Component,
     {
         contentAreaComp = std::move(c);
         addAndMakeVisible(*contentAreaComp);
-        resized();
+        if (isVisible())
+            resized();
+    }
+
+    const std::unique_ptr<juce::Component> &getContentAreaComponent() const
+    {
+        return contentAreaComp;
     }
 
     virtual void setName(const juce::String &n) override
@@ -76,11 +85,21 @@ struct NamedPanel : public juce::Component,
         repaint();
     }
 
-    virtual void enablementChanged() override
-    {
-        repaint();
-    }
+    virtual void enablementChanged() override { repaint(); }
 
+    /*
+     * Named Panels can have toggle buttons which attach to a
+     * discrete data source.
+     */
+    bool isTogglable{false};
+    void setTogglable(bool b);
+    std::unique_ptr<ToggleButton> toggleButton;
+    void setToggleDataSource(data::Discrete *d);
+
+    /*
+     * Named panels can have tab selections as their named
+     * bar.
+     */
     bool isTabbed{false};
     std::vector<std::string> tabNames{};
     size_t selectedTab{0};

--- a/include/sst/jucegui/components/ToggleButton.h
+++ b/include/sst/jucegui/components/ToggleButton.h
@@ -52,7 +52,18 @@ struct ToggleButton : public juce::Component,
         }
     };
 
+    enum struct DrawMode
+    {
+        LABELED,
+        FILLED
+    } drawMode{DrawMode::LABELED};
+
     void dataChanged() override;
+    void setDrawMode(DrawMode m)
+    {
+        drawMode = m;
+        repaint();
+    }
     void setLabel(const std::string &l) { label = l; }
     void setSource(data::Discrete *d)
     {

--- a/scripts/fix_file_comments.pl
+++ b/scripts/fix_file_comments.pl
@@ -93,5 +93,6 @@ EOH
         close(IN);
         close(OUT);
         system("mv ${q}.bak ${q}");
+        system("clang-format -i ${q}");
     }
 }

--- a/src/sst/jucegui/components/ContinuousParamEditor.cpp
+++ b/src/sst/jucegui/components/ContinuousParamEditor.cpp
@@ -24,18 +24,18 @@ ContinuousParamEditor::~ContinuousParamEditor() = default;
 
 void ContinuousParamEditor::mouseDown(const juce::MouseEvent &e)
 {
+    if (!processMouseActions())
+        return;
+
+    jassert(settings());
+    jassert(source);
+
     if (e.mods.isPopupMenu())
     {
         mouseMode = POPUP;
         onPopupMenu(e.mods);
         return;
     }
-
-    jassert(settings());
-    jassert(source);
-
-    if (source->isHidden())
-        return;
 
     mouseMode = DRAG;
     onBeginEdit();
@@ -48,7 +48,7 @@ void ContinuousParamEditor::mouseDown(const juce::MouseEvent &e)
 }
 void ContinuousParamEditor::mouseUp(const juce::MouseEvent &e)
 {
-    if (source->isHidden())
+    if (!processMouseActions())
         return;
 
     if (mouseMode == DRAG)
@@ -58,8 +58,9 @@ void ContinuousParamEditor::mouseUp(const juce::MouseEvent &e)
 
 void ContinuousParamEditor::mouseDoubleClick(const juce::MouseEvent &e)
 {
-    if (source->isHidden())
+    if (!processMouseActions())
         return;
+
     onBeginEdit();
     source->setValueFromGUI(source->getDefaultValue());
     onEndEdit();
@@ -69,7 +70,7 @@ void ContinuousParamEditor::mouseDoubleClick(const juce::MouseEvent &e)
 
 void ContinuousParamEditor::mouseDrag(const juce::MouseEvent &e)
 {
-    if (source->isHidden())
+    if (!processMouseActions())
         return;
 
     if (mouseMode != DRAG)
@@ -121,7 +122,7 @@ void ContinuousParamEditor::mouseDrag(const juce::MouseEvent &e)
 void ContinuousParamEditor::mouseWheelMove(const juce::MouseEvent &e,
                                            const juce::MouseWheelDetails &wheel)
 {
-    if (source->isHidden())
+    if (!processMouseActions())
         return;
 
     if (fabs(wheel.deltaY) < 0.0001)
@@ -150,5 +151,17 @@ void ContinuousParamEditor::mouseWheelMove(const juce::MouseEvent &e,
     }
     onEndEdit();
     repaint();
+}
+
+bool ContinuousParamEditor::processMouseActions()
+{
+    if (!source)
+        return false;
+    if (source->isHidden())
+        return false;
+    if (!isEnabled())
+        return false;
+
+    return true;
 }
 } // namespace sst::jucegui::components

--- a/src/sst/jucegui/components/DraggableTextEditableValue.cpp
+++ b/src/sst/jucegui/components/DraggableTextEditableValue.cpp
@@ -44,7 +44,14 @@ void DraggableTextEditableValue::setFromEditor()
 {
     jassert(underlyingEditor->isVisible());
     auto t = underlyingEditor->getText();
-    source->setValueAsString(t.toStdString());
+    if (t.isEmpty())
+    {
+        source->setValueFromGUI(source->getDefaultValue());
+    }
+    else
+    {
+        source->setValueAsString(t.toStdString());
+    }
     underlyingEditor->setVisible(false);
     repaint();
 }

--- a/src/sst/jucegui/components/Knob.cpp
+++ b/src/sst/jucegui/components/Knob.cpp
@@ -67,9 +67,9 @@ void Knob::paint(juce::Graphics &g)
             auto v0 = v;
             v = 2 * v - 1;
             // split between dAng and -dAnd
-            float zero01 = (0-source->getMin())/(source->getMax()-source->getMin());
+            float zero01 = (0 - source->getMin()) / (source->getMax() - source->getMin());
             // 1 -> dAng; 0 -> -dAng again so
-            start = dAng * ( 2 * zero01 - 1);
+            start = dAng * (2 * zero01 - 1);
             end = dAng * v;
         }
         auto region = knobarea.reduced(r);

--- a/src/sst/jucegui/components/ToggleButton.cpp
+++ b/src/sst/jucegui/components/ToggleButton.cpp
@@ -61,10 +61,20 @@ void ToggleButton::paint(juce::Graphics &g)
     g.setColour(bg);
     g.fillRoundedRectangle(b, rectCorner);
 
-    g.setFont(getFont(Styles::labelfont));
-    g.setColour(fg);
-    g.drawText(label, b, juce::Justification::centred);
-
+    if (drawMode == DrawMode::LABELED)
+    {
+        g.setFont(getFont(Styles::labelfont));
+        g.setColour(fg);
+        g.drawText(label, b, juce::Justification::centred);
+    }
+    else
+    {
+        if (v)
+        {
+            g.setColour(getColour(Styles::borderoncol));
+            g.fillRoundedRectangle(b.reduced(2), rectCorner);
+        }
+    }
     if (v)
         g.setColour(getColour(Styles::borderoncol));
     else

--- a/src/sst/jucegui/style/StyleAndSettingsComsumer.cpp
+++ b/src/sst/jucegui/style/StyleAndSettingsComsumer.cpp
@@ -23,7 +23,7 @@ void StyleConsumer::setStyle(const StyleSheet::ptr_t &s)
 {
     stylep = s;
     onStyleChanged();
-    
+
     auto jc = dynamic_cast<juce::Component *>(this);
     std::function<void(juce::Component *)> rec;
     rec = [&rec, s](juce::Component *comp) {

--- a/src/sst/jucegui/style/StyleSheet.cpp
+++ b/src/sst/jucegui/style/StyleSheet.cpp
@@ -61,7 +61,7 @@ struct BuiltInDeleteStyleResetter : juce::DeletedAtShutdown
 struct StyleSheetBuiltInImpl : public StyleSheet
 {
     StyleSheetBuiltInImpl() {}
-    ~StyleSheetBuiltInImpl() { DBGMARK; }
+    ~StyleSheetBuiltInImpl() {}
 
     std::unordered_map<std::string, std::unordered_map<std::string, juce::Colour>> colours;
     std::unordered_map<std::string, std::unordered_map<std::string, juce::Font>> fonts;


### PR DESCRIPTION
- enabled = false -> no events for sliders etc...
- Named Panel gets an option to be togglable
- Draggable Text gets a reset-to-default on blank string
- Remove some specious debug logging
- clang-format everywhere
- ToggleButton adds FILLED and LABELED mode