### PR TITLE
Style Fixes; Named Pamel Improvements

### DIFF
--- a/include/sst/jucegui/components/NamedPanel.h
+++ b/include/sst/jucegui/components/NamedPanel.h
@@ -45,13 +45,15 @@ struct NamedPanel : public juce::Component,
         static constexpr sclass styleClass{"namedpanel"};
         static constexpr sprop labelrulecol{"labelrule.color"};
         static constexpr sprop selectedtabcol{"selectedtab.color"};
+        static constexpr sprop selectedpanelborder{"selectedpanel.border.color"};
 
         static void initialize()
         {
             style::StyleSheet::addClass(styleClass)
                 .withBaseClass(BaseStyles::styleClass)
                 .withProperty(labelrulecol)
-                .withProperty(selectedtabcol);
+                .withProperty(selectedtabcol)
+                .withProperty(selectedpanelborder);
         }
     };
 
@@ -96,6 +98,14 @@ struct NamedPanel : public juce::Component,
     std::unique_ptr<ToggleButton> toggleButton;
     void setToggleDataSource(data::Discrete *d);
 
+    bool centeredHeader{false};
+    bool selectable{false}, selected{false};
+    void setSelected(bool b)
+    {
+        selected = b;
+        repaint();
+    }
+
     /*
      * Named panels can have tab selections as their named
      * bar.
@@ -114,6 +124,12 @@ struct NamedPanel : public juce::Component,
     juce::Rectangle<int> getHamburgerRegion();
 
     std::function<void()> onHamburger{nullptr};
+
+    void onStyleChanged() override
+    {
+        resetTabState();
+        resized();
+    }
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(NamedPanel);
 

--- a/src/sst/jucegui/components/NamedPanel.cpp
+++ b/src/sst/jucegui/components/NamedPanel.cpp
@@ -18,6 +18,7 @@
 #include <sst/jucegui/components/NamedPanel.h>
 #include <sst/jucegui/components/ToggleButton.h>
 #include <cassert>
+#include <cassert>
 
 namespace sst::jucegui::components
 {
@@ -40,6 +41,8 @@ void NamedPanel::paint(juce::Graphics &g)
     g.setColour(getColour(Styles::regionBG));
     g.fillRoundedRectangle(b.toFloat(), cornerRadius);
     g.setColour(getColour(Styles::regionBorder));
+    if (selected)
+        g.setColour(getColour(Styles::selectedpanelborder));
     g.drawRoundedRectangle(b.toFloat(), cornerRadius, 1);
 
     paintHeader(g);
@@ -77,6 +80,13 @@ void NamedPanel::paintHeader(juce::Graphics &g)
             }
         }
     }
+    else if (centeredHeader)
+    {
+        g.setFont(getFont(Styles::regionLabelFont));
+        g.setColour(getColour(Styles::regionLabelCol));
+        g.drawText(name, ht, juce::Justification::centred);
+        labelWidth = g.getCurrentFont().getStringWidth(name);
+    }
     else
     {
         g.setFont(getFont(Styles::regionLabelFont));
@@ -90,13 +100,34 @@ void NamedPanel::paintHeader(juce::Graphics &g)
 
     auto showHamburger = isEnabled() && hasHamburger;
 
-    auto q = ht.toFloat()
-                 .withTrimmedLeft(labelWidth + 4 + (isTogglable ? headerHeight - togglePad : 0))
-                 .translated(0, ht.getHeight() / 2 - 0.5)
-                 .withHeight(1)
-                 .reduced(4, 0)
-                 .withTrimmedRight(showHamburger * hamburgerSize);
-    g.fillRect(q);
+    if (centeredHeader)
+    {
+        auto q = ht.toFloat()
+                     .withWidth((ht.getWidth() - labelWidth - 2) / 2)
+                     .translated(0, ht.getHeight() / 2 - 0.5)
+                     .withHeight(1)
+                     .reduced(4, 0);
+        g.fillRect(q);
+        q = ht.toFloat()
+                .withWidth((ht.getWidth() - labelWidth - 2) / 2)
+                .translated((ht.getWidth() - labelWidth - 2) / 2 + labelWidth + 2,
+                            ht.getHeight() / 2 - 0.5)
+                .withHeight(1)
+                .reduced(4, 0);
+        g.fillRect(q);
+
+        assert(!showHamburger);
+    }
+    else
+    {
+        auto q = ht.toFloat()
+                     .withTrimmedLeft(labelWidth + 4 + (isTogglable ? headerHeight - togglePad : 0))
+                     .translated(0, ht.getHeight() / 2 - 0.5)
+                     .withHeight(1)
+                     .reduced(4, 0)
+                     .withTrimmedRight(showHamburger * hamburgerSize);
+        g.fillRect(q);
+    }
 
     if (showHamburger)
     {

--- a/src/sst/jucegui/style/StyleSheet.cpp
+++ b/src/sst/jucegui/style/StyleSheet.cpp
@@ -208,6 +208,7 @@ struct DarkSheet : public StyleSheetBuiltInImpl
             using n = components::NamedPanel::Styles;
             setColour(n::styleClass, n::labelrulecol, juce::Colour(0x70, 0x70, 0x70));
             setColour(n::styleClass, n::selectedtabcol, juce::Colour(0xFF, 0x90, 0x00));
+            setColour(n::styleClass, n::selectedpanelborder, juce::Colour(0xFF, 0x90, 0x00));
         }
 
         {
@@ -287,13 +288,13 @@ struct LightSheet : public StyleSheetBuiltInImpl
     {
         {
             using w = components::WindowPanel::Styles;
-            setColour(w::styleClass, w::backgroundgradstart, juce::Colour(240, 240, 240));
+            setColour(w::styleClass, w::backgroundgradstart, juce::Colour(220, 220, 220));
             setColour(w::styleClass, w::backgroundgradend, juce::Colour(200, 200, 200));
         }
 
         {
             using n = components::BaseStyles;
-            setColour(n::styleClass, n::regionBG, juce::Colours::white);
+            setColour(n::styleClass, n::regionBG, juce::Colour(235, 235, 235));
             setColour(n::styleClass, n::regionBorder, juce::Colour(160, 160, 160));
             setColour(n::styleClass, n::regionLabelCol, juce::Colours::black);
             setFont(n::styleClass, n::regionLabelFont, juce::Font(14));
@@ -309,6 +310,7 @@ struct LightSheet : public StyleSheetBuiltInImpl
             using n = components::NamedPanel::Styles;
             setColour(n::styleClass, n::labelrulecol, juce::Colour(50, 50, 50));
             setColour(n::styleClass, n::selectedtabcol, juce::Colour(0xFF, 0x90, 00));
+            setColour(n::styleClass, n::selectedpanelborder, juce::Colour(0xFF, 0x90, 00));
         }
 
         {


### PR DESCRIPTION
- Style Sheet fix and find way better. API change that style() can return null in early initialization path.

- Named Panel gets selected and centered label properties