### PR TITLE
StyleSheet cleanup / revamp

### DIFF
--- a/examples/component-demo/CoupledControls.h
+++ b/examples/component-demo/CoupledControls.h
@@ -1,9 +1,22 @@
-//
-// Created by Paul Walker on 5/25/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
-#ifndef SST_JUCEGUI_COUPLEDDEMO_H
-#define SST_JUCEGUI_COUPLEDDEMO_H
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_COUPLEDCONTROLS_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_COUPLEDCONTROLS_H
 
 #include <sst/jucegui/components/VSlider.h>
 #include <sst/jucegui/components/Knob.h>

--- a/examples/component-demo/CustomStyleDemo.h
+++ b/examples/component-demo/CustomStyleDemo.h
@@ -1,9 +1,22 @@
-//
-// Created by Paul Walker on 5/25/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
-#ifndef SST_JUCEGUI_CustomStyleDEMO_H
-#define SST_JUCEGUI_CustomStyleDEMO_H
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_CUSTOMSTYLEDEMO_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_CUSTOMSTYLEDEMO_H
 
 #include <sst/jucegui/components/HSlider.h>
 #include <sst/jucegui/components/NamedPanel.h>
@@ -126,22 +139,23 @@ struct CustomStyleDemo : public sst::jucegui::components::WindowPanel
     void onStyleChanged() override
     {
         const auto &sk = style();
+        // FIX ME redo
+        /*
+                sk->setColour(greenclass, sst::jucegui::components::HSlider::Styles::handlecol,
+                              juce::Colour(0x00, 0xFF, 0x00));
 
-        sk->setColour(greenclass, sst::jucegui::components::HSlider::Styles::handlecol,
-                      juce::Colour(0x00, 0xFF, 0x00));
+                sk->setFont(redclass, sst::jucegui::components::HSlider::Styles::labeltextfont,
+                            juce::Font("Comic Sans MS", 14, juce::Font::plain));
+                sk->setColour(redclass, sst::jucegui::components::HSlider::Styles::labeltextcol,
+                              juce::Colours::pink);
+                sk->setFont(redclass, sst::jucegui::components::HSlider::Styles::valuetextfont,
+                            juce::Font("Times New Roman", 16, juce::Font::bold));
+                sk->setColour(redclass, sst::jucegui::components::HSlider::Styles::valuetextcol,
+                              juce::Colours::red);
 
-        sk->setFont(redclass, sst::jucegui::components::HSlider::Styles::labeltextfont,
-                    juce::Font("Comic Sans MS", 14, juce::Font::plain));
-        sk->setColour(redclass, sst::jucegui::components::HSlider::Styles::labeltextcol,
-                      juce::Colours::pink);
-        sk->setFont(redclass, sst::jucegui::components::HSlider::Styles::valuetextfont,
-                    juce::Font("Times New Roman", 16, juce::Font::bold));
-        sk->setColour(redclass, sst::jucegui::components::HSlider::Styles::valuetextcol,
-                      juce::Colours::red);
-
-        sk->setColour(pinkclass, sst::jucegui::components::GraphicalControlStyles::guttercol,
-                      juce::Colours::pink);
-
+                sk->setColour(pinkclass,
+           sst::jucegui::components::GraphicalControlStyles::guttercol, juce::Colours::pink);
+        */
         sst::jucegui::components::WindowPanel::onStyleChanged();
     }
     std::unique_ptr<sst::jucegui::components::NamedPanel> panelOne;

--- a/examples/component-demo/DraggableTextDemo.h
+++ b/examples/component-demo/DraggableTextDemo.h
@@ -1,9 +1,22 @@
-//
-// Created by Paul Walker on 5/25/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
-#ifndef SST_JUCEGUI_DRAGGABLETEXTDEMO_H
-#define SST_JUCEGUI_DRAGGABLETEXTDEMO_H
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_DRAGGABLETEXTDEMO_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_DRAGGABLETEXTDEMO_H
 
 #include <sst/jucegui/components/DraggableTextEditableValue.h>
 #include <sst/jucegui/components/NamedPanel.h>

--- a/examples/component-demo/ExampleUtils.h
+++ b/examples/component-demo/ExampleUtils.h
@@ -1,9 +1,22 @@
-//
-// Created by Paul Walker on 5/25/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
-#ifndef SST_JUCEGUI_EXAMPLEUTILS_H
-#define SST_JUCEGUI_EXAMPLEUTILS_H
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_EXAMPLEUTILS_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_EXAMPLEUTILS_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <sst/jucegui/data/Continuous.h>

--- a/examples/component-demo/HSliderDemo.h
+++ b/examples/component-demo/HSliderDemo.h
@@ -1,11 +1,25 @@
-//
-// Created by Paul Walker on 5/25/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
-#ifndef SST_JUCEGUI_HSLIDERDEMO_H
-#define SST_JUCEGUI_HSLIDERDEMO_H
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_HSLIDERDEMO_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_HSLIDERDEMO_H
 
 #include <sst/jucegui/components/HSlider.h>
+#include <sst/jucegui/components/HSliderFilled.h>
 #include <sst/jucegui/components/NamedPanel.h>
 #include <sst/jucegui/components/WindowPanel.h>
 #include "ExampleUtils.h"
@@ -21,6 +35,8 @@ struct HSliderDemo : public sst::jucegui::components::WindowPanel
             for (int i = 0; i < 24; ++i)
             {
                 auto k = std::make_unique<sst::jucegui::components::HSlider>();
+                if (rand() % 10 > 7)
+                    k = std::make_unique<sst::jucegui::components::HSliderFilled>();
                 auto d = std::make_unique<ConcreteCM>();
 
                 if (i % 3 == 2)

--- a/examples/component-demo/KnobDemo.h
+++ b/examples/component-demo/KnobDemo.h
@@ -1,9 +1,22 @@
-//
-// Created by Paul Walker on 5/25/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
-#ifndef SST_JUCEGUI_KNOBDEMO_H
-#define SST_JUCEGUI_KNOBDEMO_H
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_KNOBDEMO_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_KNOBDEMO_H
 
 #include <sst/jucegui/components/Knob.h>
 #include <sst/jucegui/components/NamedPanel.h>

--- a/examples/component-demo/MixerPrototype.h
+++ b/examples/component-demo/MixerPrototype.h
@@ -1,9 +1,22 @@
-//
-// Created by Paul Walker on 5/25/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
-#ifndef SST_JUCEGUI_MIXERPROTO_H
-#define SST_JUCEGUI_MIXERPROTO_H
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_MIXERPROTOTYPE_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_MIXERPROTOTYPE_H
 
 #include <sst/jucegui/style/Layouts.h>
 

--- a/examples/component-demo/NamedPanelDemo.h
+++ b/examples/component-demo/NamedPanelDemo.h
@@ -1,9 +1,22 @@
-//
-// Created by Paul Walker on 5/25/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
-#ifndef SST_JUCEGUI_NAMEDPANELDEMO_H
-#define SST_JUCEGUI_NAMEDPANELDEMO_H
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_NAMEDPANELDEMO_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_NAMEDPANELDEMO_H
 
 #include <sst/jucegui/components/NamedPanel.h>
 #include <sst/jucegui/components/WindowPanel.h>
@@ -25,7 +38,6 @@ struct NamedPanelDemo : public sst::jucegui::components::WindowPanel
 
         panelThree =
             std::make_unique<sst::jucegui::components::NamedPanel>("Panel Three Long Name");
-        panelThree->setCustomClass({"greenpanel"});
         panelThree->setContentAreaComponent(std::make_unique<Solid>(juce::Colours::red));
         addAndMakeVisible(*panelThree);
     }

--- a/examples/component-demo/SSTJuceGuiDemo.cpp
+++ b/examples/component-demo/SSTJuceGuiDemo.cpp
@@ -1,6 +1,19 @@
-//
-// Created by Paul Walker on 5/24/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
@@ -15,6 +28,9 @@
 #include "TreeTableFileSystem.h"
 #include "DraggableTextDemo.h"
 #include "CustomStyleDemo.h"
+#include "TextPushButtonDemo.h"
+#include "SevenSegmentDemo.h"
+#include "VUMeterDemo.h"
 
 struct SSTJuceGuiDemo : public juce::JUCEApplication
 {
@@ -29,6 +45,7 @@ struct SSTJuceGuiDemo : public juce::JUCEApplication
 
     struct SSTMainComponent : public juce::Component
     {
+        static constexpr float scale{1.f};
         struct ClosableDW : public juce::DocumentWindow
         {
             SSTMainComponent *comp{nullptr};
@@ -51,14 +68,14 @@ struct SSTJuceGuiDemo : public juce::JUCEApplication
                 auto newt = new T();
                 newt->setStyle(sst::jucegui::style::StyleSheet::getBuiltInStyleSheet(
                     sst::jucegui::style::StyleSheet::LIGHT));
-
+                newt->setTransform(juce::AffineTransform().scaled(scale));
                 auto ss = sst::jucegui::style::StyleSheet::getBuiltInStyleSheet(
                     sst::jucegui::style::StyleSheet::LIGHT);
                 ss->dumpStyleSheetTo(std::cout);
                 newt->setSettings(std::make_shared<sst::jucegui::style::Settings>());
                 w->setContentOwned(newt, false);
 
-                w->setBounds(200, 200, 600, 600);
+                w->setBounds(200, 200, 200 + 400 * scale, 200 + 400 * scale);
 
                 w->setResizable(true, true);
                 w->setUsingNativeTitleBar(true);
@@ -76,9 +93,10 @@ struct SSTJuceGuiDemo : public juce::JUCEApplication
                 newt->setStyle(sst::jucegui::style::StyleSheet::getBuiltInStyleSheet(
                     sst::jucegui::style::StyleSheet::DARK));
                 newt->setSettings(std::make_shared<sst::jucegui::style::Settings>());
+                newt->setTransform(juce::AffineTransform().scaled(scale));
                 w->setContentOwned(newt, false);
 
-                w->setBounds(820, 200, 600, 600);
+                w->setBounds(820, 200, 200 + 400 * scale, 200 + 400 * scale);
 
                 w->setResizable(true, true);
                 w->setUsingNativeTitleBar(true);
@@ -108,6 +126,9 @@ struct SSTJuceGuiDemo : public juce::JUCEApplication
             mk<TreeTableFileSystem>();
             mk<DraggableTextDemo>();
             mk<CustomStyleDemo>();
+            mk<TextPushButtonDemo>();
+            mk<SevenSegmentDemo>();
+            mk<VUMeterDemo>();
         }
         void paint(juce::Graphics &g) override { g.fillAll(juce::Colours::black); }
         void resized() override
@@ -117,6 +138,8 @@ struct SSTJuceGuiDemo : public juce::JUCEApplication
             {
                 b->setBounds(r);
                 r = r.translated(0, 30);
+                if (r.getY() + 50 > getHeight())
+                    r = r.withY(5).withX(160);
             }
         }
 

--- a/examples/component-demo/SevenSegmentDemo.h
+++ b/examples/component-demo/SevenSegmentDemo.h
@@ -15,31 +15,27 @@
  * https://github.com/surge-synthesizer/sst-juce-gui
  */
 
-#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_MULTISWITCHDEMO_H
-#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_MULTISWITCHDEMO_H
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_SEVENSEGMENTDEMO_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_SEVENSEGMENTDEMO_H
 
-#include <sst/jucegui/components/MultiSwitch.h>
+#include <sst/jucegui/components/SevenSegmentControl.h>
 #include <sst/jucegui/components/NamedPanel.h>
 #include <sst/jucegui/components/WindowPanel.h>
 #include "ExampleUtils.h"
 
-struct MultiSwitchDemo : public sst::jucegui::components::WindowPanel
+struct SevenSegmentDemo : public sst::jucegui::components::WindowPanel
 {
-    static constexpr const char *name = "MultiSwitch";
+    static constexpr const char *name = "SevenSegment";
 
-    struct SomeMultiSwitchs : juce::Component
+    struct SomeSevenSegs : juce::Component
     {
-        SomeMultiSwitchs()
+        SomeSevenSegs()
         {
             for (int i = 0; i < 20; ++i)
             {
-                auto dir = sst::jucegui::components::MultiSwitch::VERTICAL;
-                if (i >= 15)
-                    dir = sst::jucegui::components::MultiSwitch::HORIZONTAL;
-                auto k = std::make_unique<sst::jucegui::components::MultiSwitch>(dir);
-                int nc = (i / 5) + 5;
-                if (i >= 15)
-                    nc = 5;
+                int numDigits = (int)(i / 5) + 1;
+                auto k = std::make_unique<sst::jucegui::components::SevenSegmentControl>(numDigits);
+                int nc = (int)pow(10, numDigits) - 1;
                 auto d = std::make_unique<ConcreteMultiM>(nc);
 
                 d->setValueFromModel(rand() % nc);
@@ -55,65 +51,41 @@ struct MultiSwitchDemo : public sst::jucegui::components::WindowPanel
                     std::cout << __FILE__ << ":" << __LINE__ << " popupMenu" << std::endl;
                 };
                 addAndMakeVisible(*k);
-                MultiSwitchs.push_back(std::move(k));
+                sevenSegs.push_back(std::move(k));
                 sources.push_back(std::move(d));
             }
         }
-        ~SomeMultiSwitchs()
-        {
-            for (const auto &k : MultiSwitchs)
-            {
-                k->setSource(nullptr);
-            }
-        }
+        ~SomeSevenSegs() {}
         void resized() override
         {
             auto ridx = 6;
             auto dh = 0;
             auto r = juce::Rectangle<int>(0, 0, 50, 15 * ridx).translated(3, 3);
             int kidx = 0;
-            for (const auto &k : MultiSwitchs)
+            for (const auto &k : sevenSegs)
             {
-                if (kidx < 15)
+                k->setBounds(r);
+                r = r.expanded(10, 0);
+                r = r.translated(r.getWidth() + 5, 0);
+                kidx++;
+                if (kidx % 5 == 0)
                 {
-                    k->setBounds(r);
-                    r = r.expanded(10, 0);
-                    r = r.translated(r.getWidth() + 3, 0);
-                    kidx++;
-                    if (kidx % 5 == 0)
-                    {
-                        ridx++;
-                        r = r.withX(3)
-                                .translated(0, r.getHeight() + 5)
-                                .withHeight(15 * ridx)
-                                .withWidth(50);
-                    }
-                }
-                else
-                {
-                    if (kidx == 15)
-                    {
-                        r = r.withX(3).withHeight(20).withWidth(400);
-                    }
-                    else
-                    {
-                        r = r.translated(0, r.getHeight() + 3);
-                    }
-                    r = r.withWidth((kidx - 15) * 60 + 250);
-                    k->setBounds(r);
-
-                    kidx++;
+                    ridx++;
+                    r = r.withX(3)
+                            .translated(0, r.getHeight() + 5)
+                            .withHeight(15 * ridx)
+                            .withWidth(50);
                 }
             }
         }
-        std::vector<std::unique_ptr<sst::jucegui::components::MultiSwitch>> MultiSwitchs;
+        std::vector<std::unique_ptr<sst::jucegui::components::SevenSegmentControl>> sevenSegs;
         std::vector<std::unique_ptr<sst::jucegui::data::Discrete>> sources;
     };
 
-    MultiSwitchDemo()
+    SevenSegmentDemo()
     {
         panelOne = std::make_unique<sst::jucegui::components::NamedPanel>("MultiSwitch Buttons");
-        panelOne->setContentAreaComponent(std::make_unique<SomeMultiSwitchs>());
+        panelOne->setContentAreaComponent(std::make_unique<SomeSevenSegs>());
 
         addAndMakeVisible(*panelOne);
     }

--- a/examples/component-demo/TextPushButtonDemo.h
+++ b/examples/component-demo/TextPushButtonDemo.h
@@ -1,0 +1,119 @@
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
+
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_TEXTPUSHBUTTONDEMO_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_TEXTPUSHBUTTONDEMO_H
+
+#include <sst/jucegui/components/TextPushButton.h>
+#include <sst/jucegui/components/GlyphButton.h>
+#include <sst/jucegui/components/MenuButton.h>
+#include <sst/jucegui/components/NamedPanel.h>
+#include <sst/jucegui/components/WindowPanel.h>
+#include "ExampleUtils.h"
+
+struct TextPushButtonDemo : public sst::jucegui::components::WindowPanel
+{
+    static constexpr const char *name = "Text Push Buttons";
+
+    struct SomeTPB : juce::Component
+    {
+        SomeTPB()
+        {
+            for (int i = 0; i < 5; ++i)
+            {
+                auto k = std::make_unique<sst::jucegui::components::TextPushButton>();
+                k->setLabel("Button " + std::to_string(i + 1));
+                k->setOnCallback([i]() { std::cout << "You pressed button " << i << std::endl; });
+                addAndMakeVisible(*k);
+                tpb.push_back(std::move(k));
+
+                auto g = std::make_unique<sst::jucegui::components::GlyphButton>(
+                    sst::jucegui::components::GlyphPainter::PAN);
+                g->setOnCallback([i]() { std::cout << "You pressed GB " << i << std::endl; });
+                addAndMakeVisible(*g);
+                gb.push_back(std::move(g));
+
+                auto m = std::make_unique<sst::jucegui::components::MenuButton>();
+                m->setLabel("Menu " + std::to_string(i + 1));
+                m->setOnCallback([i]() { std::cout << "You pressed MB " << i << std::endl; });
+                addAndMakeVisible(*m);
+                mb.push_back(std::move(m));
+            }
+        }
+        void resized() override
+        {
+            auto r = juce::Rectangle<int>(0, 0, 40, 18).translated(3, 3);
+            int kidx = 0;
+            for (const auto &k : tpb)
+            {
+                k->setBounds(r);
+                r = r.expanded(10, 3);
+                r = r.translated(r.getWidth() + 3, 3);
+                kidx++;
+                if (kidx % 5 == 0)
+                {
+                    r = r.withX(3).translated(0, r.getHeight() + 5).withHeight(15).withWidth(30);
+                }
+            }
+
+            r = juce::Rectangle<int>(0, 0, 40, 18).translated(3, 70);
+            kidx = 0;
+            for (const auto &k : gb)
+            {
+                k->setBounds(r);
+                r = r.expanded(10, 3);
+                r = r.translated(r.getWidth() + 3, 3);
+                kidx++;
+                if (kidx % 5 == 0)
+                {
+                    r = r.withX(3).translated(0, r.getHeight() + 5).withHeight(15).withWidth(30);
+                }
+            }
+            r = juce::Rectangle<int>(0, 0, 40, 18).translated(3, 140);
+            kidx = 0;
+            for (const auto &k : mb)
+            {
+                k->setBounds(r);
+                r = r.expanded(10, 3);
+                r = r.translated(r.getWidth() + 3, 3);
+                kidx++;
+                if (kidx % 5 == 0)
+                {
+                    r = r.withX(3).translated(0, r.getHeight() + 5).withHeight(15).withWidth(30);
+                }
+            }
+        }
+        std::vector<std::unique_ptr<sst::jucegui::components::TextPushButton>> tpb;
+        std::vector<std::unique_ptr<sst::jucegui::components::GlyphButton>> gb;
+        std::vector<std::unique_ptr<sst::jucegui::components::MenuButton>> mb;
+        std::vector<std::unique_ptr<sst::jucegui::data::BinaryDiscrete>> sources;
+    };
+
+    TextPushButtonDemo()
+    {
+        panelOne = std::make_unique<sst::jucegui::components::NamedPanel>("Push Buttons");
+        panelOne->setContentAreaComponent(std::make_unique<SomeTPB>());
+
+        addAndMakeVisible(*panelOne);
+    }
+
+    void resized() override { panelOne->setBounds(getLocalBounds().reduced(10)); }
+
+    std::unique_ptr<sst::jucegui::components::NamedPanel> panelOne;
+};
+
+#endif // SST_JUCEGUI_TOGGLEDEMO_H

--- a/examples/component-demo/ToggleDemo.h
+++ b/examples/component-demo/ToggleDemo.h
@@ -1,11 +1,25 @@
-//
-// Created by Paul Walker on 5/30/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
-#ifndef SST_JUCEGUI_TOGGLEDEMO_H
-#define SST_JUCEGUI_TOGGLEDEMO_H
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_TOGGLEDEMO_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_TOGGLEDEMO_H
 
 #include <sst/jucegui/components/ToggleButton.h>
+#include <sst/jucegui/components/ToggleButtonRadioGroup.h>
 #include <sst/jucegui/components/NamedPanel.h>
 #include <sst/jucegui/components/WindowPanel.h>
 #include "ExampleUtils.h"
@@ -29,6 +43,11 @@ struct ToggleDemo : public sst::jucegui::components::WindowPanel
 
                 d->setValueFromModel((rand() % 10 > 5) ? true : false);
 
+                if (i > 10)
+                {
+                    k->setGlyph(sst::jucegui::components::GlyphPainter::VOLUME);
+                }
+
                 k->setSource(d.get());
                 k->onBeginEdit = []() {
                     std::cout << __FILE__ << ":" << __LINE__ << " beginEdit" << std::endl;
@@ -43,6 +62,14 @@ struct ToggleDemo : public sst::jucegui::components::WindowPanel
                 toggles.push_back(std::move(k));
                 sources.push_back(std::move(d));
             }
+
+            int nc{4};
+            toggleSource = std::make_unique<ConcreteMultiM>(nc);
+            toggleSource->setValueFromModel(rand() % nc);
+
+            toggleGroup = std::make_unique<sst::jucegui::components::ToggleButtonRadioGroup>();
+            toggleGroup->setSource(toggleSource.get());
+            addAndMakeVisible(*toggleGroup);
         }
         ~SomeToggles()
         {
@@ -66,9 +93,15 @@ struct ToggleDemo : public sst::jucegui::components::WindowPanel
                     r = r.withX(3).translated(0, r.getHeight() + 5).withHeight(15).withWidth(30);
                 }
             }
+
+            auto q = juce::Rectangle<int>(0, 0, 300, 25).translated(3, 200);
+            toggleGroup->setBounds(q);
         }
         std::vector<std::unique_ptr<sst::jucegui::components::ToggleButton>> toggles;
         std::vector<std::unique_ptr<sst::jucegui::data::BinaryDiscrete>> sources;
+
+        std::unique_ptr<sst::jucegui::data::Discrete> toggleSource;
+        std::unique_ptr<sst::jucegui::components::ToggleButtonRadioGroup> toggleGroup;
     };
 
     ToggleDemo()

--- a/examples/component-demo/TreeTableFileSystem.h
+++ b/examples/component-demo/TreeTableFileSystem.h
@@ -1,9 +1,22 @@
-//
-// Created by Paul Walker on 7/31/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
-#ifndef SST_JUCEGUI_TREETABLEFILESYSTEM_H
-#define SST_JUCEGUI_TREETABLEFILESYSTEM_H
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_TREETABLEFILESYSTEM_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_TREETABLEFILESYSTEM_H
 
 #include "sst/jucegui/util/DebugHelpers.h"
 #include "sst/jucegui/data/TreeTable.h"
@@ -21,16 +34,22 @@ struct FSTreeDataEntry : public sst::jucegui::data::TreeTableData::Entry
 
     FSTreeDataEntry(const std::filesystem::path &p) : path(p)
     {
-        if (std::filesystem::is_directory(path))
+        try
         {
-            isDir = true;
-
-            for (auto const &dir_entry : std::filesystem::directory_iterator{path})
+            if (std::filesystem::is_directory(path))
             {
-                childPaths.push_back(dir_entry.path());
-                childCount++;
+                isDir = true;
+
+                for (auto const &dir_entry : std::filesystem::directory_iterator{path})
+                {
+                    childPaths.push_back(dir_entry.path());
+                    childCount++;
+                }
+                children.resize(childCount);
             }
-            children.resize(childCount);
+        }
+        catch (std::filesystem::filesystem_error &)
+        {
         }
     }
 

--- a/examples/component-demo/VSliderDemo.h
+++ b/examples/component-demo/VSliderDemo.h
@@ -1,9 +1,22 @@
-//
-// Created by Paul Walker on 5/25/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
-#ifndef SST_JUCEGUI_VSLIDERDEMO_H
-#define SST_JUCEGUI_VSLIDERDEMO_H
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_VSLIDERDEMO_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_VSLIDERDEMO_H
 
 #include <sst/jucegui/components/VSlider.h>
 #include <sst/jucegui/components/NamedPanel.h>

--- a/examples/component-demo/VUMeterDemo.h
+++ b/examples/component-demo/VUMeterDemo.h
@@ -1,0 +1,118 @@
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
+
+#ifndef SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_VUMETERDEMO_H
+#define SSTJUCEGUI_EXAMPLES_COMPONENT_DEMO_VUMETERDEMO_H
+
+#include <sst/jucegui/components/VUMeter.h>
+#include <sst/jucegui/components/NamedPanel.h>
+#include <sst/jucegui/components/WindowPanel.h>
+#include "ExampleUtils.h"
+
+struct VUMeterDemo : public sst::jucegui::components::WindowPanel
+{
+    static constexpr const char *name = "VU Meters";
+
+    struct SomeVU : juce::Component, juce::Timer
+    {
+        SomeVU()
+        {
+            for (int i = 0; i < nVU; ++i)
+            {
+                auto v = std::make_unique<sst::jucegui::components::VUMeter>();
+                v->direction = sst::jucegui::components::VUMeter::VERTICAL;
+                addAndMakeVisible(*v);
+                vus[i] = std::move(v);
+                values[0][i] = (rand() % 1000) * 0.0017f;
+                values[1][i] = values[0][i] * (1.1 - (rand() % 1000) * 0.001f * .2);
+                vus[i]->setLevels(values[0][1], values[1][i]);
+
+                auto vh = std::make_unique<sst::jucegui::components::VUMeter>();
+                vh->direction = sst::jucegui::components::VUMeter::HORIZONTAL;
+                addAndMakeVisible(*vh);
+                vusH[i] = std::move(vh);
+                vusH[i]->setLevels(values[0][1], values[1][i]);
+            }
+            startTimerHz(30);
+        }
+        ~SomeVU() { stopTimer(); }
+
+        void timerCallback() override
+        {
+            for (int i = 0; i < nVU; ++i)
+            {
+                if (rand() % 100 > 96)
+                {
+                    values[0][i] = (rand() % 1000) * 0.0017f;
+                    auto mv = (1.1 - (rand() % 1000) * 0.001f * .2);
+                    values[1][i] = values[0][i] * mv;
+                }
+                else
+                {
+                    values[0][i] = 0.9 * values[0][i];
+                    values[1][i] = 0.9 * values[1][i];
+                }
+
+                vusH[i]->setLevels(values[0][i], values[1][i]);
+                vusH[i]->repaint();
+                vus[i]->setLevels(values[0][i], values[1][i]);
+                vus[i]->repaint();
+            }
+        }
+        void resized() override
+        {
+            auto r = juce::Rectangle<int>(0, 0, 200, 15).translated(3, 3);
+            int kidx = 0;
+            for (const auto &k : vusH)
+            {
+                k->setBounds(r);
+                r = r.translated(0, r.getHeight() + 3)
+                        .withHeight(r.getHeight() + 3)
+                        .withWidth(r.getWidth() + 10);
+                kidx++;
+            }
+
+            r = juce::Rectangle<int>(300, 0, 15, 200).translated(3, 3);
+            for (const auto &k : vus)
+            {
+                k->setBounds(r);
+                r = r.translated(r.getWidth() + 3, 0)
+                        .withHeight(r.getHeight() + 20)
+                        .withWidth(r.getWidth() + 3);
+            }
+        }
+
+        static constexpr int nVU{5};
+
+        std::array<std::array<float, nVU>, 2> values;
+        std::array<std::unique_ptr<sst::jucegui::components::VUMeter>, nVU> vus, vusH;
+    };
+
+    VUMeterDemo()
+    {
+        panelOne = std::make_unique<sst::jucegui::components::NamedPanel>("Toggle Buttons");
+        panelOne->setContentAreaComponent(std::make_unique<SomeVU>());
+
+        addAndMakeVisible(*panelOne);
+    }
+
+    void resized() override { panelOne->setBounds(getLocalBounds().reduced(10)); }
+
+    std::unique_ptr<sst::jucegui::components::NamedPanel> panelOne;
+};
+
+#endif // SST_JUCEGUI_TOGGLEDEMO_H

--- a/examples/scxt-wireframes/MainWindow.h
+++ b/examples/scxt-wireframes/MainWindow.h
@@ -1,9 +1,22 @@
-//
-// Created by Paul Walker on 12/26/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
-#ifndef SST_JUCEGUI_MAINWINDOW_H
-#define SST_JUCEGUI_MAINWINDOW_H
+#ifndef SSTJUCEGUI_EXAMPLES_SCXT_WIREFRAMES_MAINWINDOW_H
+#define SSTJUCEGUI_EXAMPLES_SCXT_WIREFRAMES_MAINWINDOW_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <sst/jucegui/style/StyleSheet.h>

--- a/examples/scxt-wireframes/SCXTWireframesMain.cpp
+++ b/examples/scxt-wireframes/SCXTWireframesMain.cpp
@@ -1,6 +1,19 @@
-//
-// Created by Paul Walker on 12/25/22.
-//
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
 
 #include <juce_gui_basics/juce_gui_basics.h>
 

--- a/include/sst/jucegui/components/BaseStyles.h
+++ b/include/sst/jucegui/components/BaseStyles.h
@@ -20,138 +20,161 @@
 
 #include <sst/jucegui/style/StyleSheet.h>
 
-namespace sst::jucegui::components
+namespace sst::jucegui::components::base_styles
 {
-struct BaseStyles
+#define SCLASS(x)                                                                                  \
+    static constexpr style::StyleSheet::Class styleClass { #x }
+#define PROP(x)                                                                                    \
+    static constexpr style::StyleSheet::Property x { #x }
+#define PROP_NAMED(x, y)                                                                           \
+    static constexpr style::StyleSheet::Property x { y }
+#define PROP_FONT(x)                                                                               \
+    static constexpr style::StyleSheet::Property x { #x, style::StyleSheet::Property::FONT }
+#define PROP_OFF(x)                                                                                \
+    static constexpr style::StyleSheet::Property x##_off { #x ".off" }
+#define PROP_HOVER(x)                                                                              \
+    static constexpr style::StyleSheet::Property x##_hover { #x ".hover" }
+#define PROP_HOVER_OFF(x)                                                                          \
+    static constexpr style::StyleSheet::Property x##_hover_off { #x ".hover.off" }
+
+#define PROP_FULL_HOVER(x)                                                                         \
+    PROP(x);                                                                                       \
+    PROP_OFF(x);                                                                                   \
+    PROP_HOVER(x);                                                                                 \
+    PROP_HOVER_OFF(x);
+
+#define WITH_PROP_FULL_HOVER(x)                                                                    \
+    withProperty(x).withProperty(x##_off).withProperty(x##_hover).withProperty(x##_hover_off)
+
+struct Base
 {
-    using sclass = style::StyleSheet::Class;
-    using sprop = style::StyleSheet::Property;
-    static constexpr sclass styleClass{"base"};
+    SCLASS(base);
+    PROP(background);
+    static void initialize() { style::StyleSheet::addClass(styleClass).withProperty(background); }
+};
 
-    static constexpr sprop regionBorder{"region.border.color"};
-    static constexpr sprop regionBG{"region.background.color"};
-    static constexpr sprop regionLabelCol{"region.label.color"};
-    static constexpr sprop regionLabelFont{"region.label.font", style::StyleSheet::Property::FONT};
-
+struct Outlined
+{
+    SCLASS(outlined);
+    PROP(outline);
+    PROP(brightoutline);
     static void initialize()
     {
-        style::StyleSheet::addClass(styleClass)
-            .withProperty(regionBorder)
-            .withProperty(regionBG)
-            .withProperty(regionLabelCol)
-            .withProperty(regionLabelFont);
+        style::StyleSheet::addClass(styleClass).withProperty(outline).withProperty(brightoutline);
     }
 };
 
-struct ControlStyles : BaseStyles
+struct ValueBearing
 {
-    using sclass = style::StyleSheet::Class;
-    using sprop = style::StyleSheet::Property;
-    static constexpr sclass styleClass{"controls"};
-
-    static constexpr sprop controlLabelCol{"control.label.color"};
-    static constexpr sprop controlLabelFont{"control.label.font",
-                                            style::StyleSheet::Property::FONT};
-
+    SCLASS(value_bearing);
+    PROP(value);
+    PROP_HOVER(value);
+    PROP(valuelabel);
+    PROP_HOVER(valuelabel);
     static void initialize()
     {
         style::StyleSheet::addClass(styleClass)
-            .withBaseClass(BaseStyles::styleClass)
-            .withProperty(controlLabelCol)
-            .withProperty(controlLabelFont);
+            .withProperty(value)
+            .withProperty(value_hover)
+            .withProperty(valuelabel)
+            .withProperty(valuelabel_hover);
     }
 };
 
-// Knobs, Sliders, etc...
-struct GraphicalControlStyles : ControlStyles
+struct ModulationValueBearing
 {
-    using sclass = style::StyleSheet::Class;
-    using sprop = style::StyleSheet::Property;
-    static constexpr sclass styleClass{"graphical.controls"};
-
-    static constexpr sprop backgroundcol{"background.color"};
-    static constexpr sprop valcol{"value.color"};
-    static constexpr sprop handlecol{"handle.color"};
-    static constexpr sprop handlebordercol{"handle.border.color"};
-    static constexpr sprop guttercol{"gutter.color"};
-
-    static constexpr sprop handlehovcol{"handle.hover.color"};
-    static constexpr sprop gutterhovcol{"gutter.hover.color"};
-
-    static constexpr sprop modvalcol{"modulationvalue.color"};
-    static constexpr sprop modvalnegcol{"modulationnegativevalue.color"};
-    static constexpr sprop modactivecol{"modulationactive.color"};
-    static constexpr sprop modothercol{"modulationother.color"};
-    static constexpr sprop modhandlecol{"modhandle.color"};
-    static constexpr sprop modhandlehovcol{"modhandle.hover.color"};
-
-    static constexpr sprop labeltextcol{"labeltext.color"};
-    static constexpr sprop valuetextcol{"valuetext.color"};
-
-    static constexpr sprop labeltextfont{"labeltext.font", sprop::FONT};
-    static constexpr sprop valuetextfont{"valuetext.font", sprop::FONT};
-
+    SCLASS(modulation_value_bearing);
+    PROP_FULL_HOVER(modulation_value);
+    PROP_FULL_HOVER(modulation_opposite_value);
+    PROP(modulated_by_selected);
+    PROP(modulated_by_other);
     static void initialize()
     {
         style::StyleSheet::addClass(styleClass)
-            .withBaseClass(ControlStyles::styleClass)
-            .withProperty(backgroundcol)
-            .withProperty(valcol)
-            .withProperty(handlecol)
-            .withProperty(handlebordercol)
-            .withProperty(handlehovcol)
-            .withProperty(guttercol)
-            .withProperty(gutterhovcol)
-            .withProperty(modvalcol)
-            .withProperty(modactivecol)
-            .withProperty(modvalnegcol)
-            .withProperty(modothercol)
-            .withProperty(modhandlecol)
-            .withProperty(modhandlehovcol)
-            .withProperty(labeltextfont)
-            .withProperty(labeltextcol)
-            .withProperty(valuetextfont)
-            .withProperty(valuetextcol);
+            .WITH_PROP_FULL_HOVER(modulation_value)
+            .WITH_PROP_FULL_HOVER(modulation_opposite_value)
+            .withProperty(modulated_by_selected)
+            .withProperty(modulated_by_other);
     }
 };
 
-// Switches, Buttons, Draggable Typeins, Combo Boxes, etc...
-struct TextualControlStyles : ControlStyles
+struct ValueGutter
 {
-    using sclass = style::StyleSheet::Class;
-    using sprop = style::StyleSheet::Property;
-    static constexpr sclass styleClass{"textual.controls"};
+    SCLASS(value_gutter);
+    PROP(gutter);
+    PROP_HOVER(gutter);
+    static void initialize()
+    {
+        style::StyleSheet::addClass(styleClass).withProperty(gutter).withProperty(gutter_hover);
+    }
+};
 
-    static constexpr sprop bordercol{"border.color"};
-    static constexpr sprop borderoncol{"borderon.color"};
-    static constexpr sprop onbgcol{"onbg.color"};
-    static constexpr sprop offbgcol{"offbg.color"};
-    static constexpr sprop hoveronbgcol{"hoveronbg.color"};
-    static constexpr sprop hoveroffbgcol{"hoveroffbg.color"};
-    static constexpr sprop textoncol{"texton.color"};
-    static constexpr sprop textoffcol{"textoff.color"};
-    static constexpr sprop texthoveroncol{"texthoveron.color"};
-    static constexpr sprop texthoveroffcol{"texthoveroff.color"};
+struct GraphicalHandle
+{
+    SCLASS(graphical_handle);
+    PROP(handle);
+    PROP_HOVER(handle);
+    PROP(modulation_handle);
+    PROP_HOVER(modulation_handle);
+    PROP(handle_outline);
+    static void initialize()
+    {
+        style::StyleSheet::addClass(styleClass)
+            .withProperty(handle)
+            .withProperty(handle_hover)
+            .withProperty(modulation_handle)
+            .withProperty(modulation_handle_hover)
+            .withProperty(handle_outline);
+    }
+};
 
-    static constexpr sprop labelfont{"label.font", sprop::FONT};
+struct BaseLabel
+{
+    SCLASS(baselabel);
+
+    PROP(labelcolor);
+    PROP_HOVER(labelcolor);
+    PROP_FONT(labelfont);
 
     static void initialize()
     {
         style::StyleSheet::addClass(styleClass)
-            .withBaseClass(ControlStyles::styleClass)
-            .withProperty(bordercol)
-            .withProperty(borderoncol)
-            .withProperty(onbgcol)
-            .withProperty(offbgcol)
-            .withProperty(hoveronbgcol)
-            .withProperty(hoveroffbgcol)
-            .withProperty(textoncol)
-            .withProperty(textoffcol)
-            .withProperty(texthoveroncol)
-            .withProperty(texthoveroffcol)
-
+            .withProperty(labelcolor)
+            .withProperty(labelcolor_hover)
             .withProperty(labelfont);
     }
 };
-} // namespace sst::jucegui::components
+
+struct PushButton : Outlined
+{
+    SCLASS(pushbutton);
+
+    PROP(fill);
+    PROP_HOVER(fill);
+    PROP_NAMED(fill_pressed, "fill.pressed");
+
+    static void initialize()
+    {
+        style::StyleSheet::addClass(styleClass)
+            .withBaseClass(Outlined::styleClass)
+            .withProperty(fill)
+            .withProperty(fill_hover)
+            .withProperty(fill_pressed);
+    }
+};
+
+static void initialize()
+{
+    Base::initialize();
+    Outlined::initialize();
+    ValueBearing::initialize();
+    ModulationValueBearing::initialize();
+    ValueGutter::initialize();
+    GraphicalHandle::initialize();
+    BaseLabel::initialize();
+    PushButton::initialize();
+}
+
+} // namespace sst::jucegui::components::base_styles
+
 #endif // SST_JUCEGUI_BASESTYLES_H

--- a/include/sst/jucegui/components/CallbackButtonComponent.h
+++ b/include/sst/jucegui/components/CallbackButtonComponent.h
@@ -32,12 +32,6 @@ template <typename T> struct CallbackButtonComponent : public juce::Component
     void setLabel(const std::string &l) { label = l; }
     std::string getLabel() const { return label; }
 
-    void setIsInactiveValue(bool b)
-    {
-        isInactive = b;
-        asT()->repaint();
-    }
-
     void mouseEnter(const juce::MouseEvent &e) override
     {
         asT()->startHover();
@@ -51,13 +45,22 @@ template <typename T> struct CallbackButtonComponent : public juce::Component
 
     void mouseDown(const juce::MouseEvent &e) override
     {
+        isPressed = true;
         if (onCB)
             onCB();
+        repaint();
     }
+
+    void mouseUp(const juce::MouseEvent &e) override
+    {
+        isPressed = false;
+        repaint();
+    }
+
+    bool isPressed{false};
 
   protected:
     std::string label;
-    bool isInactive{false};
     std::function<void()> onCB{nullptr};
 };
 } // namespace sst::jucegui::components

--- a/include/sst/jucegui/components/ContinuousParamEditor.h
+++ b/include/sst/jucegui/components/ContinuousParamEditor.h
@@ -35,16 +35,26 @@ struct ContinuousParamEditor : public juce::Component,
                                public EditableComponentBase<ContinuousParamEditor>,
                                public style::SettingsConsumer
 {
-    struct Styles : GraphicalControlStyles
+    struct Styles : base_styles::ValueBearing,
+                    base_styles::ModulationValueBearing,
+                    base_styles::GraphicalHandle,
+                    base_styles::ValueGutter,
+                    base_styles::BaseLabel,
+                    base_styles::Base,
+                    base_styles::Outlined
     {
-        using sclass = style::StyleSheet::Class;
-        using sprop = style::StyleSheet::Property;
-        static constexpr sclass styleClass{"continuousParamEditor"};
+        SCLASS(continuousparameditor);
 
         static void initialize()
         {
             style::StyleSheet::addClass(styleClass)
-                .withBaseClass(GraphicalControlStyles::styleClass);
+                .withBaseClass(base_styles::ValueBearing::styleClass)
+                .withBaseClass(base_styles::ModulationValueBearing::styleClass)
+                .withBaseClass(base_styles::GraphicalHandle::styleClass)
+                .withBaseClass(base_styles::BaseLabel::styleClass)
+                .withBaseClass(base_styles::Base::styleClass)
+                .withBaseClass(base_styles::Outlined::styleClass)
+                .withBaseClass(base_styles::ValueGutter::styleClass);
         }
     };
 

--- a/include/sst/jucegui/components/DraggableTextEditableValue.h
+++ b/include/sst/jucegui/components/DraggableTextEditableValue.h
@@ -36,18 +36,17 @@ struct DraggableTextEditableValue : public juce::Component,
                                     public style::SettingsConsumer,
                                     public style::StyleConsumer
 {
-    struct Styles : TextualControlStyles
+    struct Styles : base_styles::Outlined, base_styles::BaseLabel, base_styles::ValueBearing
     {
-        using sclass = style::StyleSheet::Class;
-        using sprop = style::StyleSheet::Property;
-        static constexpr sclass styleClass{"draggabletexteditor"};
-
-        static constexpr sprop bgedcol{"background.editing.color"};
+        SCLASS(draggabletexteditor);
+        PROP(background_editing);
         static void initialize()
         {
             style::StyleSheet::addClass(styleClass)
-                .withBaseClass(TextualControlStyles::styleClass)
-                .withProperty(bgedcol);
+                .withBaseClass(base_styles::Outlined::styleClass)
+                .withBaseClass(base_styles::BaseLabel::styleClass)
+                .withBaseClass(base_styles::ValueBearing::styleClass)
+                .withProperty(background_editing);
         }
     };
 

--- a/include/sst/jucegui/components/GlyphButton.h
+++ b/include/sst/jucegui/components/GlyphButton.h
@@ -24,7 +24,6 @@
 #include <sst/jucegui/style/StyleSheet.h>
 #include <sst/jucegui/data/Discrete.h>
 #include <sst/jucegui/components/BaseStyles.h>
-#include "ToggleButton.h"
 
 #include <string>
 
@@ -42,15 +41,15 @@ struct GlyphButton : public CallbackButtonComponent<GlyphButton>,
     GlyphButton(GlyphPainter::GlyphType type);
     ~GlyphButton();
 
-    struct Styles : TextualControlStyles
+    struct Styles : base_styles::PushButton, base_styles::BaseLabel
     {
-        using sclass = style::StyleSheet::Class;
-        using sprop = style::StyleSheet::Property;
-        static constexpr sclass styleClass{"glyphbutton"};
+        SCLASS(glyphbutton);
 
         static void initialize()
         {
-            style::StyleSheet::addClass(styleClass).withBaseClass(MenuButton::Styles::styleClass);
+            style::StyleSheet::addClass(styleClass)
+                .withBaseClass(base_styles::PushButton::styleClass)
+                .withBaseClass(base_styles::BaseLabel::styleClass);
         }
     };
 

--- a/include/sst/jucegui/components/GlyphPainter.h
+++ b/include/sst/jucegui/components/GlyphPainter.h
@@ -49,7 +49,8 @@ struct GlyphPainter : public juce::Component,
         HAMBURGER
     } glyph;
 
-    struct Styles : ControlStyles
+    // The glyph acts like a label so uses hte label color
+    struct Styles : base_styles::BaseLabel
     {
         using sclass = style::StyleSheet::Class;
         using sprop = style::StyleSheet::Property;
@@ -57,7 +58,8 @@ struct GlyphPainter : public juce::Component,
 
         static void initialize()
         {
-            style::StyleSheet::addClass(styleClass).withBaseClass(ControlStyles::styleClass);
+            style::StyleSheet::addClass(styleClass)
+                .withBaseClass(base_styles::BaseLabel::styleClass);
         }
     };
 

--- a/include/sst/jucegui/components/Label.h
+++ b/include/sst/jucegui/components/Label.h
@@ -27,7 +27,7 @@ namespace sst::jucegui::components
 {
 struct Label : public juce::Component, public style::StyleConsumer, public style::SettingsConsumer
 {
-    struct Styles : ControlStyles
+    struct Styles : base_styles::BaseLabel
     {
         using sclass = style::StyleSheet::Class;
         using sprop = style::StyleSheet::Property;
@@ -35,7 +35,8 @@ struct Label : public juce::Component, public style::StyleConsumer, public style
 
         static void initialize()
         {
-            style::StyleSheet::addClass(styleClass).withBaseClass(ControlStyles::styleClass);
+            style::StyleSheet::addClass(styleClass)
+                .withBaseClass(base_styles::BaseLabel::styleClass);
         }
     };
 
@@ -58,8 +59,8 @@ struct Label : public juce::Component, public style::StyleConsumer, public style
 
     void paint(juce::Graphics &g) override
     {
-        g.setColour(getColour(Styles::controlLabelCol));
-        g.setFont(getFont(Styles::controlLabelFont));
+        g.setColour(getColour(Styles::labelcolor));
+        g.setFont(getFont(Styles::labelfont));
         g.drawText(text, getLocalBounds(), justification);
     }
 

--- a/include/sst/jucegui/components/MenuButton.h
+++ b/include/sst/jucegui/components/MenuButton.h
@@ -42,15 +42,18 @@ struct MenuButton : public CallbackButtonComponent<MenuButton>,
     MenuButton();
     ~MenuButton();
 
-    struct Styles : TextualControlStyles
+    struct Styles : base_styles::Outlined, base_styles::BaseLabel
     {
-        using sclass = style::StyleSheet::Class;
-        using sprop = style::StyleSheet::Property;
-        static constexpr sclass styleClass{"menubutton"};
+        SCLASS(menubutton);
+
+        PROP_HOVER(menuarrow);
 
         static void initialize()
         {
-            style::StyleSheet::addClass(styleClass).withBaseClass(TextualControlStyles::styleClass);
+            style::StyleSheet::addClass(styleClass)
+                .withBaseClass(base_styles::Outlined::styleClass)
+                .withBaseClass(base_styles::BaseLabel::styleClass)
+                .withProperty(menuarrow_hover);
         }
     };
 

--- a/include/sst/jucegui/components/MultiSwitch.h
+++ b/include/sst/jucegui/components/MultiSwitch.h
@@ -44,15 +44,22 @@ struct MultiSwitch : public DiscreteParamEditor,
     MultiSwitch(Direction d = VERTICAL);
     ~MultiSwitch();
 
-    struct Styles : TextualControlStyles
+    struct Styles : base_styles::Outlined,
+                    base_styles::Base,
+                    base_styles::ValueBearing,
+                    base_styles::BaseLabel
     {
-        using sclass = style::StyleSheet::Class;
-        using sprop = style::StyleSheet::Property;
-        static constexpr sclass styleClass{"multiswitch"};
+        SCLASS(multiswitch);
+        PROP_HOVER(unselected);
 
         static void initialize()
         {
-            style::StyleSheet::addClass(styleClass).withBaseClass(TextualControlStyles::styleClass);
+            style::StyleSheet::addClass(styleClass)
+                .withBaseClass(base_styles::Base::styleClass)
+                .withBaseClass(base_styles::Outlined::styleClass)
+                .withBaseClass(base_styles::ValueBearing::styleClass)
+                .withBaseClass(base_styles::BaseLabel::styleClass)
+                .withProperty(unselected_hover);
         }
     };
 

--- a/include/sst/jucegui/components/NamedPanel.h
+++ b/include/sst/jucegui/components/NamedPanel.h
@@ -37,23 +37,21 @@ struct NamedPanel : public juce::Component,
 {
     static constexpr int outerMargin = 2, cornerRadius = 2, headerHeight = 20, togglePad = 3;
 
-    struct Styles : BaseStyles
+    struct Styles : base_styles::Base, base_styles::Outlined, base_styles::BaseLabel
     {
-        using sclass = style::StyleSheet::Class;
-        using sprop = style::StyleSheet::Property;
+        SCLASS(namedpanel);
 
-        static constexpr sclass styleClass{"namedpanel"};
-        static constexpr sprop labelrulecol{"labelrule.color"};
-        static constexpr sprop selectedtabcol{"selectedtab.color"};
-        static constexpr sprop selectedpanelborder{"selectedpanel.border.color"};
+        PROP(labelrule);
+        PROP(selectedtab);
 
         static void initialize()
         {
             style::StyleSheet::addClass(styleClass)
-                .withBaseClass(BaseStyles::styleClass)
-                .withProperty(labelrulecol)
-                .withProperty(selectedtabcol)
-                .withProperty(selectedpanelborder);
+                .withBaseClass(base_styles::Base::styleClass)
+                .withBaseClass(base_styles::Outlined::styleClass)
+                .withBaseClass(base_styles::BaseLabel::styleClass)
+                .withProperty(labelrule)
+                .withProperty(selectedtab);
         }
     };
 

--- a/include/sst/jucegui/components/NamedPanelDivider.h
+++ b/include/sst/jucegui/components/NamedPanelDivider.h
@@ -34,19 +34,13 @@ struct NamedPanelDivider : public juce::Component,
 {
     static constexpr int outerMargin = 2, cornerRadius = 2, headerHeight = 20, togglePad = 3;
 
-    struct Styles : BaseStyles
+    struct Styles : base_styles::Outlined
     {
-        using sclass = style::StyleSheet::Class;
-        using sprop = style::StyleSheet::Property;
-
-        static constexpr sclass styleClass{"namedpaneldivider"};
-        static constexpr sprop dividercol{"divider.color"};
-
+        SCLASS(namedpaneldivider);
         static void initialize()
         {
             style::StyleSheet::addClass(styleClass)
-                .withBaseClass(BaseStyles::styleClass)
-                .withProperty(dividercol);
+                .withBaseClass(base_styles::Outlined::styleClass);
         }
     };
 

--- a/include/sst/jucegui/components/SevenSegmentControl.h
+++ b/include/sst/jucegui/components/SevenSegmentControl.h
@@ -39,19 +39,15 @@ struct SevenSegmentControl : public DiscreteParamEditor,
     SevenSegmentControl(int numDigits = 2);
     ~SevenSegmentControl();
 
-    struct Styles : TextualControlStyles
+    struct Styles : base_styles::BaseLabel
     {
-        using sclass = style::StyleSheet::Class;
-        using sprop = style::StyleSheet::Property;
-        static constexpr sclass styleClass{"sevensegmentcontrol"};
-
+        SCLASS(sevensegmentdisplay);
         static void initialize()
         {
-            style::StyleSheet::addClass(styleClass).withBaseClass(ControlStyles::styleClass);
+            style::StyleSheet::addClass(styleClass)
+                .withBaseClass(base_styles::BaseLabel::styleClass);
         }
     };
-
-    bool hasJogButtons{false};
 
     void mouseDrag(const juce::MouseEvent &e) override;
     void mouseDown(const juce::MouseEvent &e) override;

--- a/include/sst/jucegui/components/TabularizedTreeViewer.h
+++ b/include/sst/jucegui/components/TabularizedTreeViewer.h
@@ -40,7 +40,7 @@ struct TabularizedTreeViewer : public juce::Component,
     TabularizedTreeViewer();
     ~TabularizedTreeViewer() = default;
 
-    struct Styles : ControlStyles
+    struct Styles : base_styles::BaseLabel
     {
         using sclass = style::StyleSheet::Class;
         using sprop = style::StyleSheet::Property;
@@ -55,7 +55,7 @@ struct TabularizedTreeViewer : public juce::Component,
         static void initialize()
         {
             style::StyleSheet::addClass(styleClass)
-                .withBaseClass(ControlStyles::styleClass)
+                .withBaseClass(base_styles::BaseLabel::styleClass)
                 .withProperty(toggleboxcol)
                 .withProperty(toggleglyphcol)
                 .withProperty(toggleglyphhovercol)

--- a/include/sst/jucegui/components/TextPushButton.h
+++ b/include/sst/jucegui/components/TextPushButton.h
@@ -42,15 +42,15 @@ struct TextPushButton : public CallbackButtonComponent<TextPushButton>,
     TextPushButton();
     ~TextPushButton();
 
-    struct Styles : TextualControlStyles
+    struct Styles : base_styles::BaseLabel, base_styles::PushButton
     {
-        using sclass = style::StyleSheet::Class;
-        using sprop = style::StyleSheet::Property;
-        static constexpr sclass styleClass{"textpushbutton"};
+        SCLASS(textpushbutton);
 
         static void initialize()
         {
-            style::StyleSheet::addClass(styleClass).withBaseClass(TextualControlStyles::styleClass);
+            style::StyleSheet::addClass(styleClass)
+                .withBaseClass(base_styles::PushButton::styleClass)
+                .withBaseClass(base_styles::BaseLabel::styleClass);
         }
     };
 

--- a/include/sst/jucegui/components/ToggleButton.h
+++ b/include/sst/jucegui/components/ToggleButton.h
@@ -40,15 +40,15 @@ struct ToggleButton : DiscreteParamEditor,
     ToggleButton();
     ~ToggleButton();
 
-    struct Styles : TextualControlStyles
+    struct Styles : base_styles::PushButton, base_styles::BaseLabel, base_styles::ValueBearing
     {
-        using sclass = style::StyleSheet::Class;
-        using sprop = style::StyleSheet::Property;
-        static constexpr sclass styleClass{"togglebutton"};
-
+        SCLASS(togglebutton);
         static void initialize()
         {
-            style::StyleSheet::addClass(styleClass).withBaseClass(TextualControlStyles::styleClass);
+            style::StyleSheet::addClass(styleClass)
+                .withBaseClass(base_styles::PushButton::styleClass)
+                .withBaseClass(base_styles::BaseLabel::styleClass)
+                .withBaseClass(base_styles::ValueBearing::styleClass);
         }
     };
 
@@ -80,6 +80,8 @@ struct ToggleButton : DiscreteParamEditor,
     void paint(juce::Graphics &g) override;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ToggleButton)
+
+    bool isPressed{false};
 
   private:
     std::string label;

--- a/include/sst/jucegui/components/ToggleButtonRadioGroup.h
+++ b/include/sst/jucegui/components/ToggleButtonRadioGroup.h
@@ -34,25 +34,12 @@
 namespace sst::jucegui::components
 {
 struct ToggleButtonRadioGroup : public juce::Component,
-                                public style::StyleConsumer,
                                 public style::SettingsConsumer,
                                 public EditableComponentBase<ToggleButtonRadioGroup>,
                                 public data::Discrete::DataListener
 {
     ToggleButtonRadioGroup();
     ~ToggleButtonRadioGroup();
-
-    struct Styles : TextualControlStyles
-    {
-        using sclass = style::StyleSheet::Class;
-        using sprop = style::StyleSheet::Property;
-        static constexpr sclass styleClass{"togglebuttonradiogroup"};
-
-        static void initialize()
-        {
-            style::StyleSheet::addClass(styleClass).withBaseClass(TextualControlStyles::styleClass);
-        }
-    };
 
     void dataChanged() override;
     void setSource(data::Discrete *d)
@@ -63,6 +50,13 @@ struct ToggleButtonRadioGroup : public juce::Component,
         if (data)
             data->addGUIDataListener(this);
         dataChanged();
+        repaint();
+    }
+
+    void sourceVanished(data::Discrete *d) override
+    {
+        data->removeGUIDataListener(this);
+        data = nullptr;
         repaint();
     }
 

--- a/include/sst/jucegui/components/VUMeter.h
+++ b/include/sst/jucegui/components/VUMeter.h
@@ -33,25 +33,23 @@ struct VUMeter : public juce::Component, public style::StyleConsumer, public sty
         HORIZONTAL
     } direction{VERTICAL};
 
-    struct Styles : ControlStyles
+    struct Styles : base_styles::Outlined
     {
-        using sclass = style::StyleSheet::Class;
-        using sprop = style::StyleSheet::Property;
-        static constexpr sclass styleClass{"vumeter"};
+        SCLASS(vumeter);
 
-        static constexpr sprop vugutter{"vumetergutter.color"};
-        static constexpr sprop vugradstart{"vumetergradstart.color"};
-        static constexpr sprop vugradend{"vumetergradend.color"};
-        static constexpr sprop vuoverload{"vumeteroverload.color"};
+        PROP(vu_gutter);
+        PROP(vu_gradstart);
+        PROP(vu_gradend);
+        PROP(vu_overload);
 
         static void initialize()
         {
             style::StyleSheet::addClass(styleClass)
-                .withBaseClass(ControlStyles::styleClass)
-                .withProperty(vugutter)
-                .withProperty(vugradstart)
-                .withProperty(vugradend)
-                .withProperty(vuoverload);
+                .withBaseClass(base_styles::Outlined::styleClass)
+                .withProperty(vu_gutter)
+                .withProperty(vu_gradstart)
+                .withProperty(vu_gradend)
+                .withProperty(vu_overload);
         }
     };
 
@@ -68,7 +66,7 @@ struct VUMeter : public juce::Component, public style::StyleConsumer, public sty
     {
         if (direction == VERTICAL)
         {
-            g.setColour(getColour(Styles::vugutter));
+            g.setColour(getColour(Styles::vu_gutter));
             g.fillRect(getLocalBounds().reduced(1));
 
             float zerodb = (0.7937 * getHeight());
@@ -80,31 +78,62 @@ struct VUMeter : public juce::Component, public style::StyleConsumer, public sty
             auto vl = getHeight() - scale(L) * getHeight();
             auto vr = getHeight() - scale(R) * getHeight();
 
-            auto fg = juce::ColourGradient::vertical(getColour(Styles::vugradend), zerodb,
-                                                     getColour(Styles::vugradstart), getHeight());
+            auto fg = juce::ColourGradient::vertical(getColour(Styles::vu_gradstart), zerodb,
+                                                     getColour(Styles::vu_gradend), getHeight());
             g.setGradientFill(fg);
             g.fillRect(0.f, vl, getWidth() / 2.f - 0.5, 1.f * getHeight() - vl);
             g.fillRect(getWidth() / 2.f + 0.5, vr, getWidth() / 2.f - 0.5, 1.f * getHeight() - vr);
 
             if (vl < getHeight() - zerodb)
             {
-                g.setColour(getColour(Styles::vuoverload));
+                g.setColour(getColour(Styles::vu_overload));
                 g.fillRect(0.f, vl, getWidth() / 2.f - 0.5, getHeight() - zerodb - vl);
             }
 
             if (vr < getHeight() - zerodb)
             {
-                g.setColour(getColour(Styles::vuoverload));
+                g.setColour(getColour(Styles::vu_overload));
                 g.fillRect(getWidth() / 2.f + 0.5, vr, getWidth() / 2.f - 0.5,
                            getHeight() - zerodb - vr);
             }
 
-            g.setColour(getColour(Styles::regionBorder));
+            g.setColour(getColour(Styles::outline));
             g.drawRect(getLocalBounds(), 1);
         }
         else
         {
-            g.fillAll(juce::Colours::red);
+            g.setColour(getColour(Styles::vu_gutter));
+            g.fillRect(getLocalBounds().reduced(1));
+
+            float zerodb = (0.7937 * getWidth());
+            auto scale = [](float x) {
+                x = std::clamp(0.5f * x, 0.f, 1.f);
+                return powf(x, 0.3333333333f);
+            };
+
+            auto vl = scale(L) * getWidth();
+            auto vr = scale(R) * getWidth();
+
+            auto fg = juce::ColourGradient::horizontal(getColour(Styles::vu_gradend), 0,
+                                                       getColour(Styles::vu_gradstart), zerodb);
+            g.setGradientFill(fg);
+            g.fillRect(0.f, 0.f, vl, getHeight() / 2.f - 0.5);
+            g.fillRect(0.f, getHeight() / 2.f + 0.5, vr, getHeight() / 2.f - 0.5);
+
+            if (vl > zerodb)
+            {
+                g.setColour(getColour(Styles::vu_overload));
+                g.fillRect(zerodb, 0.f, vl - zerodb, getWidth() / 2.f - 0.5);
+            }
+
+            if (vr > zerodb)
+            {
+                g.setColour(getColour(Styles::vu_overload));
+                g.fillRect(zerodb, getHeight() / 2.f + 0.5, vr - zerodb, getWidth() / 2.f - 0.5);
+            }
+
+            g.setColour(getColour(Styles::outline));
+            g.drawRect(getLocalBounds(), 1);
         }
     }
 };

--- a/include/sst/jucegui/components/WindowPanel.h
+++ b/include/sst/jucegui/components/WindowPanel.h
@@ -31,17 +31,13 @@ struct WindowPanel : public juce::Component,
 {
     struct Styles
     {
-        using sclass = style::StyleSheet::Class;
-        using sprop = style::StyleSheet::Property;
-        static constexpr sclass styleClass{"windowpanel"};
-        static constexpr sprop backgroundgradstart{"bgstart.color"};
-        static constexpr sprop backgroundgradend{"bgend.color"};
+        SCLASS(windowpanel);
+        PROP(bgstart);
+        PROP(bgend);
 
         static void initialize()
         {
-            style::StyleSheet::addClass(styleClass)
-                .withProperty(backgroundgradend)
-                .withProperty(backgroundgradstart);
+            style::StyleSheet::addClass(styleClass).withProperty(bgstart).withProperty(bgend);
         }
     };
 
@@ -50,8 +46,8 @@ struct WindowPanel : public juce::Component,
 
     void paint(juce::Graphics &g) override
     {
-        auto cg = juce::ColourGradient::vertical(getColour(Styles::backgroundgradstart), 0,
-                                                 getColour(Styles::backgroundgradend), getHeight());
+        auto cg = juce::ColourGradient::vertical(getColour(Styles::bgstart), 0,
+                                                 getColour(Styles::bgend), getHeight());
         g.setGradientFill(cg);
         g.fillRect(getLocalBounds());
     }

--- a/include/sst/jucegui/data/Discrete.h
+++ b/include/sst/jucegui/data/Discrete.h
@@ -27,8 +27,12 @@ struct Discrete : public Labeled
 {
     virtual ~Discrete()
     {
+        supressListenerModification = true;
         for (auto *l : guilisteners)
+        {
             l->sourceVanished(this);
+        }
+        supressListenerModification = false;
     }
 
     struct DataListener
@@ -38,8 +42,13 @@ struct Discrete : public Labeled
         virtual void dataChanged() = 0;
         virtual void sourceVanished(Discrete *) = 0;
     };
+    bool supressListenerModification{false};
     void addGUIDataListener(DataListener *l) { guilisteners.insert(l); }
-    void removeGUIDataListener(DataListener *l) { guilisteners.erase(l); }
+    void removeGUIDataListener(DataListener *l)
+    {
+        if (!supressListenerModification)
+            guilisteners.erase(l);
+    }
     void addModelDataListener(DataListener *l) { modellisteners.insert(l); }
     void removeModelDataListener(DataListener *l) { modellisteners.erase(l); }
 

--- a/include/sst/jucegui/style/StyleAndSettingsConsumer.h
+++ b/include/sst/jucegui/style/StyleAndSettingsConsumer.h
@@ -52,7 +52,7 @@ struct StyleConsumer
     StyleSheet::Class customClass{""};
     void setCustomClass(const StyleSheet::Class &sc)
     {
-        customClass = sc;
+        customClass.copyFrom(sc);
         StyleSheet::extendInheritanceMap(customClass, styleClass);
     }
 

--- a/scripts/fix_file_comments.pl
+++ b/scripts/fix_file_comments.pl
@@ -19,6 +19,13 @@ find(
     'src'
 );
 
+find(
+    {
+        wanted => \&findfiles,
+    },
+    'examples'
+);
+
 
 
 sub findfiles

--- a/scripts/fix_header_guards.pl
+++ b/scripts/fix_header_guards.pl
@@ -19,6 +19,13 @@ find(
     'src'
 );
 
+find(
+    {
+        wanted => \&findfiles,
+    },
+    'examples'
+);
+
 
 sub findfiles
 {
@@ -32,6 +39,7 @@ sub findfiles
         $hg =~ s:\.:_:g;
         $hg =~ s:-:_:g;
         $hg =~ s:src:sstjucegui_src:;
+        $hg =~ s:examples:sstjucegui_examples:;
         $hg = uc($hg);
         print "$f -> $hg\n";
 

--- a/src/sst/jucegui/components/ButtonPainter.hxx
+++ b/src/sst/jucegui/components/ButtonPainter.hxx
@@ -1,0 +1,79 @@
+//
+// Created by Paul Walker on 10/15/23.
+//
+
+#ifndef SST_JUCEGUI_BUTTONPAINTER_HXX
+#define SST_JUCEGUI_BUTTONPAINTER_HXX
+
+#include <juce_graphics/juce_graphics.h>
+
+namespace sst::jucegui::components
+{
+template <typename T> void paintButtonBG(T *that, juce::Graphics &g)
+{
+    float rectCorner = 1.5;
+
+    auto b = that->getLocalBounds().reduced(1).toFloat();
+
+    auto bg = that->getColour(T::Styles::fill);
+
+    if (that->isPressed)
+    {
+        bg = that->getColour(T::Styles::fill_pressed);
+    }
+    else if (that->isHovered)
+    {
+        bg = that->getColour(T::Styles::fill_hover);
+    }
+
+    g.setColour(bg);
+    g.fillRoundedRectangle(b, rectCorner);
+
+    auto ip = that->isPressed;
+    auto gr =
+        juce::ColourGradient::vertical(bg.withAlpha(0.f), that->getHeight() * 0.6,
+                                       ip ? bg.brighter(0.1) : bg.darker(0.3), that->getHeight());
+    g.setGradientFill(gr);
+    g.fillRoundedRectangle(b, rectCorner);
+
+    gr = juce::ColourGradient::vertical(ip ? bg.darker(0.2) : bg.brighter(0.1), 0,
+                                        bg.withAlpha(0.f), that->getHeight() * 0.1);
+    g.setGradientFill(gr);
+    g.fillRoundedRectangle(b, rectCorner);
+
+    g.setColour(that->getColour(T::Styles::outline));
+    g.drawRoundedRectangle(b, rectCorner, 1);
+}
+
+// Only call this in the 'on' state
+template <typename T> void paintButtonOnValueBG(T *that, juce::Graphics &g)
+{
+    float rectCorner = 1.5;
+
+    auto b = that->getLocalBounds().reduced(1).toFloat();
+    auto bg = that->getColour(T::Styles::value);
+
+    if (that->isHovered)
+    {
+        bg = that->getColour(T::Styles::value_hover);
+    }
+
+    g.setColour(bg);
+    g.fillRoundedRectangle(b, rectCorner);
+
+    auto gr = juce::ColourGradient::vertical(bg.withAlpha(0.f), that->getHeight() * 0.6,
+                                             bg.brighter(0.3), that->getHeight());
+    g.setGradientFill(gr);
+    g.fillRoundedRectangle(b, rectCorner);
+
+    gr = juce::ColourGradient::vertical(bg.darker(0.5), 0, bg.withAlpha(0.f),
+                                        that->getHeight() * 0.2);
+    g.setGradientFill(gr);
+    g.fillRoundedRectangle(b, rectCorner);
+
+    g.setColour(that->getColour(T::Styles::outline));
+    g.drawRoundedRectangle(b, rectCorner, 1);
+}
+} // namespace sst::jucegui::components
+
+#endif // SST_JUCEGUI_BUTTONPAINTER_HXX

--- a/src/sst/jucegui/components/ContinuousParamEditor.cpp
+++ b/src/sst/jucegui/components/ContinuousParamEditor.cpp
@@ -61,6 +61,12 @@ void ContinuousParamEditor::mouseDoubleClick(const juce::MouseEvent &e)
     if (!processMouseActions())
         return;
 
+    if (e.mods.isShiftDown())
+    {
+        // std::cout << "Shift DoubleClick" << std::endl;
+        // TODO: put edit typein gesture here perhaps?
+    }
+
     onBeginEdit();
     continuous()->setValueFromGUI(continuous()->getDefaultValue());
     onEndEdit();

--- a/src/sst/jucegui/components/DraggableTextEditableValue.cpp
+++ b/src/sst/jucegui/components/DraggableTextEditableValue.cpp
@@ -60,28 +60,18 @@ void DraggableTextEditableValue::paint(juce::Graphics &g)
 {
     if (underlyingEditor->isVisible())
     {
-        g.setColour(getColour(Styles::onbgcol));
+        g.setColour(getColour(Styles::background_editing));
+        g.fillRoundedRectangle(getLocalBounds().toFloat(), 3.f);
     }
-    else if (isHovered)
-    {
-        g.setColour(getColour(Styles::hoveroffbgcol));
-    }
-    else
-    {
-        g.setColour(getColour(Styles::offbgcol));
-    }
-    g.fillRoundedRectangle(getLocalBounds().toFloat(), 3.f);
-    g.setColour(getColour(Styles::bordercol));
+
+    g.setColour(getColour(Styles::brightoutline));
     g.drawRoundedRectangle(getLocalBounds().toFloat(), 3.f, 1.f);
     if (continuous() && !underlyingEditor->isVisible())
     {
         g.setFont(getFont(Styles::labelfont));
-        if (underlyingEditor->isVisible())
-            g.setColour(getColour(Styles::textoncol));
-        if (!isHovered)
-            g.setColour(getColour(Styles::textoffcol));
-        else
-            g.setColour(getColour(Styles::texthoveroffcol));
+        g.setColour(getColour(Styles::labelcolor));
+        if (isHovered)
+            g.setColour(getColour(Styles::labelcolor_hover));
         g.drawText(continuous()->getValueAsString(), getLocalBounds(),
                    juce::Justification::centred);
     }

--- a/src/sst/jucegui/components/GlyphButton.cpp
+++ b/src/sst/jucegui/components/GlyphButton.cpp
@@ -18,6 +18,7 @@
 #include "sst/jucegui/components/GlyphButton.h"
 #include "sst/jucegui/components/GlyphPainter.h"
 #include "sst/jucegui/components/MenuButton.h"
+#include "ButtonPainter.hxx"
 
 namespace sst::jucegui::components
 {
@@ -30,39 +31,11 @@ GlyphButton::~GlyphButton() {}
 
 void GlyphButton::paint(juce::Graphics &g)
 {
-    float rectCorner = 1.5;
-
-    auto b = getLocalBounds().reduced(1).toFloat();
-    auto v = !isInactive;
-
-    auto bg = getColour(Styles::offbgcol);
-    auto fg = getColour(Styles::textoffcol);
-    if (v)
-    {
-        if (isHovered)
-        {
-            bg = getColour(Styles::hoveronbgcol);
-            fg = getColour(Styles::texthoveroncol);
-        }
-        else
-        {
-            bg = getColour(Styles::onbgcol);
-            fg = getColour(Styles::textoncol);
-        }
-    }
-    else if (isHovered)
-    {
-        bg = getColour(Styles::hoveroffbgcol);
-        fg = getColour(Styles::texthoveroffcol);
-    }
-
-    g.setColour(bg);
-    g.fillRoundedRectangle(b, rectCorner);
-
-    g.setColour(fg);
+    paintButtonBG(this, g);
+    if (isHovered)
+        g.setColour(getColour(Styles::labelcolor_hover));
+    else
+        g.setColour(getColour(Styles::labelcolor));
     GlyphPainter::paintGlyph(g, getLocalBounds().reduced(glyphButtonPad), glyph);
-
-    g.setColour(getColour(Styles::bordercol));
-    g.drawRoundedRectangle(b, rectCorner, 1);
 }
 } // namespace sst::jucegui::components

--- a/src/sst/jucegui/components/GlyphPainter.cpp
+++ b/src/sst/jucegui/components/GlyphPainter.cpp
@@ -205,7 +205,7 @@ static void paintHamburgerGlyph(juce::Graphics &g, const juce::Rectangle<int> &i
 }
 void GlyphPainter::paint(juce::Graphics &g)
 {
-    g.setColour(getColour(Styles::controlLabelCol));
+    g.setColour(getColour(Styles::labelcolor));
     paintGlyph(g, getLocalBounds(), glyph);
 };
 

--- a/src/sst/jucegui/components/HSlider.cpp
+++ b/src/sst/jucegui/components/HSlider.cpp
@@ -43,15 +43,22 @@ void HSlider::paint(juce::Graphics &g)
 
     if (showLabel)
     {
-        g.setColour(getColour(Styles::labeltextcol));
-        g.setFont(getFont(Styles::labeltextfont));
+        if (isHovered)
+            g.setColour(getColour(Styles::labelcolor_hover));
+        else
+            g.setColour(getColour(Styles::labelcolor));
+        g.setFont(getFont(Styles::labelfont));
         g.drawText(continuous()->getLabel(), getLocalBounds().reduced(2, 1),
                    juce::Justification::bottomLeft);
     }
     if (showValue)
     {
-        g.setColour(getColour(Styles::valuetextcol));
-        g.setFont(getFont(Styles::valuetextfont));
+        if (isHovered)
+            g.setColour(getColour(Styles::labelcolor_hover));
+        else
+            g.setColour(getColour(Styles::labelcolor));
+
+        g.setFont(getFont(Styles::labelfont));
         g.drawText(continuous()->getValueAsString(), getLocalBounds().reduced(2, 1),
                    juce::Justification::bottomRight);
     }
@@ -72,24 +79,24 @@ void HSlider::paint(juce::Graphics &g)
         if (r.getY() > newY)
             r = r.withY(newY);
     }
-    g.setColour(getColour(Styles::backgroundcol));
+    g.setColour(getColour(Styles::outline));
     g.fillRoundedRectangle(r.toFloat(), gutterheight * 0.25);
 
     if (isHovered)
-        g.setColour(getColour(Styles::gutterhovcol));
+        g.setColour(getColour(Styles::gutter_hover));
     else
-        g.setColour(getColour(Styles::guttercol));
+        g.setColour(getColour(Styles::gutter));
     auto gutter = r.reduced(1).toFloat();
     g.fillRoundedRectangle(gutter, gutterheight * 0.25);
 
     if (modulationDisplay == FROM_ACTIVE)
     {
-        g.setColour(getColour(Styles::modactivecol));
+        g.setColour(getColour(Styles::modulated_by_selected));
         g.fillRoundedRectangle(gutter.reduced(2), gutterheight * 0.25);
     }
     else if (modulationDisplay == FROM_OTHER)
     {
-        g.setColour(getColour(Styles::modothercol));
+        g.setColour(getColour(Styles::modulated_by_other));
         g.fillRoundedRectangle(gutter.reduced(2), gutterheight * 0.25);
     }
 
@@ -104,13 +111,19 @@ void HSlider::paint(juce::Graphics &g)
         if (t > b)
             std::swap(t, b);
         auto val = gutter.withLeft(t).withRight(b);
-        g.setColour(getColour(Styles::valcol));
+        if (isHovered)
+            g.setColour(getColour(Styles::value_hover));
+        else
+            g.setColour(getColour(Styles::value));
         g.fillRoundedRectangle(val, gutterheight * 0.25);
     }
     else
     {
         auto val = gutter.withTrimmedRight(w);
-        g.setColour(getColour(Styles::valcol));
+        if (isHovered)
+            g.setColour(getColour(Styles::value_hover));
+        else
+            g.setColour(getColour(Styles::value));
         g.fillRoundedRectangle(val, gutterheight * 0.25);
     }
 
@@ -127,6 +140,14 @@ void HSlider::paint(juce::Graphics &g)
             gutter.withTrimmedLeft(gutter.getWidth() - hm).withWidth(1).expanded(0, 4).getCentre();
         mpr = juce::Rectangle<float>(2 * hanRadius, 2 * hanRadius).withCentre(mpc);
 
+        auto modvalcol = getColour(Styles::modulation_value);
+        if (isHovered)
+            modvalcol = getColour(Styles::modulation_value_hover);
+
+        auto modvaloppcol = getColour(Styles::modulation_opposite_value);
+        if (isHovered)
+            modvaloppcol = getColour(Styles::modulation_opposite_value_hover);
+
         // draw rules
         {
             auto t = hc.getX();
@@ -134,7 +155,7 @@ void HSlider::paint(juce::Graphics &g)
             if (t > b)
                 std::swap(t, b);
             auto val = gutter.withLeft(t).withRight(b);
-            g.setColour(getColour(Styles::modvalcol));
+            g.setColour(modvalcol);
             g.fillRoundedRectangle(val, gutterheight * 0.25);
         }
 
@@ -145,23 +166,27 @@ void HSlider::paint(juce::Graphics &g)
             if (t > b)
                 std::swap(t, b);
             auto val = gutter.withLeft(t).withRight(b);
-            g.setColour(getColour(Styles::modvalnegcol));
+            g.setColour(modvaloppcol);
             g.fillRoundedRectangle(val, gutterheight * 0.25);
         }
     }
 
     if (isHovered)
-        g.setColour(getColour(Styles::handlehovcol));
+        g.setColour(getColour(Styles::handle_hover));
     else
-        g.setColour(getColour(Styles::handlecol));
+        g.setColour(getColour(Styles::handle));
     g.fillEllipse(hr);
+    g.setColour(getColour(Styles::handle_outline));
+    g.drawEllipse(hr, 1);
     if (isEditingMod)
     {
         if (isHovered)
-            g.setColour(getColour(Styles::modhandlehovcol));
+            g.setColour(getColour(Styles::modulation_handle_hover));
         else
-            g.setColour(getColour(Styles::modhandlecol));
+            g.setColour(getColour(Styles::modulation_handle));
         g.fillEllipse(mpr);
+        g.setColour(getColour(Styles::handle_outline));
+        g.drawEllipse(mpr, 1);
     }
 }
 

--- a/src/sst/jucegui/components/HSliderFilled.cpp
+++ b/src/sst/jucegui/components/HSliderFilled.cpp
@@ -45,24 +45,24 @@ void HSliderFilled::paint(juce::Graphics &g)
     auto r = getLocalBounds().toFloat();
     auto rectRad = 2;
 
-    g.setColour(getColour(Styles::backgroundcol));
+    g.setColour(getColour(Styles::outline));
     g.fillRoundedRectangle(r.toFloat(), rectRad);
 
     if (isHovered)
-        g.setColour(getColour(Styles::gutterhovcol));
+        g.setColour(getColour(Styles::gutter_hover));
     else
-        g.setColour(getColour(Styles::guttercol));
+        g.setColour(getColour(Styles::gutter));
     auto gutter = r.reduced(2).toFloat();
     g.fillRoundedRectangle(gutter, rectRad);
 
     if (modulationDisplay == FROM_ACTIVE)
     {
-        g.setColour(getColour(Styles::modactivecol));
+        g.setColour(getColour(Styles::modulated_by_selected));
         g.fillRoundedRectangle(gutter.reduced(2), rectRad);
     }
     else if (modulationDisplay == FROM_OTHER)
     {
-        g.setColour(getColour(Styles::modothercol));
+        g.setColour(getColour(Styles::modulated_by_other));
         g.fillRoundedRectangle(gutter.reduced(2), rectRad);
     }
 
@@ -77,13 +77,19 @@ void HSliderFilled::paint(juce::Graphics &g)
         if (t > b)
             std::swap(t, b);
         auto val = gutter.withLeft(t).withRight(b);
-        g.setColour(getColour(Styles::valcol));
+        if (isHovered)
+            g.setColour(getColour(Styles::value_hover));
+        else
+            g.setColour(getColour(Styles::value));
         g.fillRoundedRectangle(val, rectRad);
     }
     else
     {
         auto val = gutter.withTrimmedRight(w);
-        g.setColour(getColour(Styles::valcol));
+        if (isHovered)
+            g.setColour(getColour(Styles::value_hover));
+        else
+            g.setColour(getColour(Styles::value));
         g.fillRoundedRectangle(val, rectRad);
     }
 
@@ -107,7 +113,7 @@ void HSliderFilled::paint(juce::Graphics &g)
             if (t > b)
                 std::swap(t, b);
             auto val = gutter.withLeft(t).withRight(b);
-            g.setColour(getColour(Styles::modvalcol));
+            g.setColour(getColour(Styles::modulation_value));
             g.fillRoundedRectangle(val, rectRad);
         }
 
@@ -118,22 +124,25 @@ void HSliderFilled::paint(juce::Graphics &g)
             if (t > b)
                 std::swap(t, b);
             auto val = gutter.withLeft(t).withRight(b);
-            g.setColour(getColour(Styles::modvalnegcol));
+            g.setColour(getColour(Styles::modulation_opposite_value));
             g.fillRoundedRectangle(val, rectRad);
         }
     }
 
     if (isHovered)
-        g.setColour(getColour(Styles::handlehovcol));
+        g.setColour(getColour(Styles::handle_hover));
     else
-        g.setColour(getColour(Styles::handlecol));
+        g.setColour(getColour(Styles::handle));
     g.fillRect(hr);
     if (isEditingMod)
     {
+        /*
         if (isHovered)
             g.setColour(getColour(Styles::modhandlehovcol));
         else
             g.setColour(getColour(Styles::modhandlecol));
+            FIX
+            */
         g.fillEllipse(mpr);
     }
 }

--- a/src/sst/jucegui/components/Knob.cpp
+++ b/src/sst/jucegui/components/Knob.cpp
@@ -39,8 +39,11 @@ void Knob::paint(juce::Graphics &g)
     if (drawLabel)
     {
         auto textarea = b.withTrimmedTop(b.getWidth());
-        g.setColour(getColour(Styles::labeltextcol));
-        g.setFont(getFont(Styles::labeltextfont));
+        if (isHovered)
+            g.setColour(getColour(Styles::labelcolor_hover));
+        else
+            g.setColour(getColour(Styles::labelcolor));
+        g.setFont(getFont(Styles::labelfont));
         g.drawText(continuous()->getLabel(), textarea, juce::Justification::centred);
     }
 }

--- a/src/sst/jucegui/components/KnobPainter.hxx
+++ b/src/sst/jucegui/components/KnobPainter.hxx
@@ -140,17 +140,20 @@ template <typename T, typename S> void knobPainter(juce::Graphics &g, T *that, S
 
     // outer gutter edge
     auto pOut = pacman(0, -0.005);
-    g.setColour(that->getColour(T::Styles::backgroundcol));
+    g.setColour(that->getColour(T::Styles::background));
     g.fillPath(pOut);
 
     // inner gutter
     auto pIn = pacman(1);
-    g.setColour(that->getColour(T::Styles::guttercol));
+    g.setColour(that->getColour(T::Styles::gutter));
     g.fillPath(pIn);
 
     // value gutter
     pIn = pathWithReduction(2, source->getValue01());
-    g.setColour(that->getColour(T::Styles::valcol));
+    if (that->isHovered)
+        g.setColour(that->getColour(T::Styles::value_hover));
+    else
+        g.setColour(that->getColour(T::Styles::value));
     g.fillPath(pIn);
 
     // modulation arcs
@@ -159,12 +162,12 @@ template <typename T, typename S> void knobPainter(juce::Graphics &g, T *that, S
         if (that->isEditingMod)
         {
             pIn = modPath(5, source->getValue01(), source->getModulationValuePM1(), 1);
-            g.setColour(that->getColour(T::Styles::modvalcol));
+            g.setColour(that->getColour(T::Styles::modulation_value));
             g.fillPath(pIn);
             if (source->isModulationBipolar())
             {
                 pIn = modPath(5, source->getValue01(), source->getModulationValuePM1(), -1);
-                g.setColour(that->getColour(T::Styles::modvalnegcol));
+                g.setColour(that->getColour(T::Styles::modulation_opposite_value));
                 g.fillPath(pIn);
             }
         }
@@ -198,26 +201,26 @@ template <typename T, typename S> void knobPainter(juce::Graphics &g, T *that, S
     auto er = 2;
     if (that->isHovered)
     {
-        g.setColour(that->getColour(T::Styles::handlecol));
+        g.setColour(that->getColour(T::Styles::handle));
         g.fillEllipse(hc.getX() - er, hc.getY() - er, er * 2 + 1, er * 2 + 1);
     }
     else
     {
-        g.setColour(that->getColour(T::Styles::handlecol).withAlpha(0.4f));
+        g.setColour(that->getColour(T::Styles::handle).withAlpha(0.4f));
         g.fillEllipse(hc.getX() - er, hc.getY() - er, er * 2 + 1, er * 2 + 1);
-        g.setColour(that->getColour(T::Styles::handlecol).withAlpha(0.7f));
+        g.setColour(that->getColour(T::Styles::handle).withAlpha(0.7f));
         g.drawEllipse(hc.getX() - er, hc.getY() - er, er * 2 + 1, er * 2 + 1, 1);
     }
     if (that->modulationDisplay == ContinuousParamEditor::FROM_ACTIVE)
     {
         pOut = circle(8);
-        g.setColour(that->getColour(T::Styles::modactivecol));
+        g.setColour(that->getColour(T::Styles::modulated_by_selected));
         g.fillPath(pOut);
     }
     if (that->modulationDisplay == ContinuousParamEditor::FROM_OTHER)
     {
         pOut = circle(8);
-        g.setColour(that->getColour(T::Styles::modothercol));
+        g.setColour(that->getColour(T::Styles::modulated_by_other));
         g.fillPath(pOut);
     }
 }

--- a/src/sst/jucegui/components/MenuButton.cpp
+++ b/src/sst/jucegui/components/MenuButton.cpp
@@ -28,36 +28,24 @@ void MenuButton::paint(juce::Graphics &g)
     float rectCorner = 1.5;
 
     auto b = getLocalBounds().reduced(1).toFloat();
-    auto v = !isInactive;
 
-    auto bg = getColour(Styles::offbgcol);
-    auto fg = getColour(Styles::textoffcol);
-    if (v)
+    auto ol = getColour(Styles::brightoutline);
+    auto tx = getColour(Styles::labelcolor);
+    auto ar = tx;
+    if (isHovered)
     {
-        if (isHovered)
-        {
-            bg = getColour(Styles::hoveronbgcol);
-            fg = getColour(Styles::texthoveroncol);
-        }
-        else
-        {
-            bg = getColour(Styles::onbgcol);
-            fg = getColour(Styles::textoncol);
-        }
-    }
-    else if (isHovered)
-    {
-        bg = getColour(Styles::hoveroffbgcol);
-        fg = getColour(Styles::texthoveroffcol);
+        tx = getColour(Styles::labelcolor_hover);
+        ar = getColour(Styles::menuarrow_hover);
     }
 
-    g.setColour(bg);
-    g.fillRoundedRectangle(b, rectCorner);
+    g.setColour(ol);
+    g.drawRoundedRectangle(b, rectCorner, 1);
 
     g.setFont(getFont(Styles::labelfont));
-    g.setColour(fg);
+    g.setColour(tx);
     g.drawText(label, b.withTrimmedLeft(2), juce::Justification::centredLeft);
 
+    g.setColour(ar);
     auto q = b.withTrimmedRight(2);
     q = q.withLeft(q.getRight() - 10);
     auto cy = q.getCentreY();
@@ -74,8 +62,5 @@ void MenuButton::paint(juce::Graphics &g)
     p.closeSubPath();
 
     g.fillPath(p);
-
-    g.setColour(getColour(Styles::bordercol));
-    g.drawRoundedRectangle(b, rectCorner, 1);
 }
 } // namespace sst::jucegui::components

--- a/src/sst/jucegui/components/MultiSwitch.cpp
+++ b/src/sst/jucegui/components/MultiSwitch.cpp
@@ -52,16 +52,16 @@ void MultiSwitch::paint(juce::Graphics &g)
         auto bgb = b.withHeight(h * nItems);
         if (direction == HORIZONTAL)
             bgb = b.withWidth(h * nItems);
-        auto bg = getColour(Styles::offbgcol);
-        auto fg = getColour(Styles::textoffcol);
+        auto bg = getColour(Styles::background);
+        auto fg = getColour(Styles::labelcolor);
 
         g.setColour(bg);
         g.fillRoundedRectangle(bgb, rectCorner);
 
-        g.setColour(getColour(Styles::bordercol));
+        g.setColour(getColour(Styles::outline));
         g.drawRoundedRectangle(bgb, rectCorner, 1);
 
-        for (int i = 0; i < nItems; ++i)
+        for (int i = 1; i < nItems; ++i)
         {
             juce::Rectangle<float> rule;
             if (direction == VERTICAL)
@@ -69,7 +69,7 @@ void MultiSwitch::paint(juce::Graphics &g)
             else
                 rule = b.toFloat().reduced(0, 2).withX(h * i - 0.5).withWidth(1);
 
-            g.setColour(getColour(Styles::bordercol));
+            g.setColour(getColour(Styles::outline));
             g.fillRect(rule);
         }
 
@@ -80,12 +80,13 @@ void MultiSwitch::paint(juce::Graphics &g)
             if (direction == VERTICAL)
             {
                 txt = b.toFloat().withHeight(h).translated(0, h * i);
-                txtbg = txt.reduced(3, 2);
+                txtbg =
+                    txt.reduced(1, i == 0 ? 1 : 0).withTrimmedBottom(1 + (i != 0 ? 0.5f : 0.0f));
             }
             else
             {
                 txt = b.toFloat().withWidth(h).translated(h * i, 0);
-                txtbg = txt.reduced(3, 3);
+                txtbg = txt.reduced((i == 0 ? 1 : 0), 1).withTrimmedRight(i == nItems - 1 ? 1 : 0);
             }
 
             bool isH;
@@ -98,31 +99,31 @@ void MultiSwitch::paint(juce::Graphics &g)
             if (i == data->getValue() - data->getMin())
             {
                 if (isH)
-                    g.setColour(getColour(Styles::hoveronbgcol));
+                    g.setColour(getColour(Styles::value_hover));
                 else
-                    g.setColour(getColour(Styles::onbgcol));
-                g.fillRoundedRectangle(txtbg, 3);
+                    g.setColour(getColour(Styles::value));
+                g.fillRoundedRectangle(txtbg, rectCorner - 1);
             }
             else if (isH)
             {
-                g.setColour(getColour(Styles::hoveroffbgcol));
-                g.fillRoundedRectangle(txtbg, 3);
+                g.setColour(getColour(Styles::unselected_hover));
+                g.fillRoundedRectangle(txtbg, rectCorner - 1);
             }
 
             if (i == data->getValue() - data->getMin())
             {
-                g.setColour(getColour(Styles::textoncol));
+                g.setColour(getColour(Styles::valuelabel));
                 if (isH)
                 {
-                    g.setColour(getColour(Styles::texthoveroncol));
+                    g.setColour(getColour(Styles::valuelabel_hover));
                 }
             }
             else
             {
-                g.setColour(getColour(Styles::textoffcol));
+                g.setColour(getColour(Styles::labelcolor));
                 if (isH)
                 {
-                    g.setColour(getColour(Styles::texthoveroffcol));
+                    g.setColour(getColour(Styles::labelcolor_hover));
                 }
             }
             g.setFont(getFont(Styles::labelfont));

--- a/src/sst/jucegui/components/NamedPanel.cpp
+++ b/src/sst/jucegui/components/NamedPanel.cpp
@@ -38,11 +38,9 @@ void NamedPanel::paint(juce::Graphics &g)
         return;
     }
     auto b = getLocalBounds().reduced(outerMargin);
-    g.setColour(getColour(Styles::regionBG));
+    g.setColour(getColour(Styles::background));
     g.fillRoundedRectangle(b.toFloat(), cornerRadius);
-    g.setColour(getColour(Styles::regionBorder));
-    if (selected)
-        g.setColour(getColour(Styles::selectedpanelborder));
+    g.setColour(getColour(Styles::brightoutline));
     g.drawRoundedRectangle(b.toFloat(), cornerRadius, 1);
 
     paintHeader(g);
@@ -68,34 +66,34 @@ void NamedPanel::paintHeader(juce::Graphics &g)
 
             if (i == selectedTab)
             {
-                g.setFont(getFont(Styles::regionLabelFont));
-                g.setColour(getColour(Styles::selectedtabcol));
+                g.setFont(getFont(Styles::labelfont));
+                g.setColour(getColour(Styles::selectedtab));
                 g.drawText("[ " + s + " ]", p, juce::Justification::centred);
             }
             else
             {
-                g.setFont(getFont(Styles::regionLabelFont));
-                g.setColour(getColour(Styles::regionLabelCol));
+                g.setFont(getFont(Styles::labelfont));
+                g.setColour(getColour(Styles::labelcolor));
                 g.drawText(s, p, juce::Justification::centred);
             }
         }
     }
     else if (centeredHeader)
     {
-        g.setFont(getFont(Styles::regionLabelFont));
-        g.setColour(getColour(Styles::regionLabelCol));
+        g.setFont(getFont(Styles::labelfont));
+        g.setColour(getColour(Styles::labelcolor));
         g.drawText(name, ht, juce::Justification::centred);
         labelWidth = g.getCurrentFont().getStringWidth(name);
     }
     else
     {
-        g.setFont(getFont(Styles::regionLabelFont));
-        g.setColour(getColour(Styles::regionLabelCol));
+        g.setFont(getFont(Styles::labelfont));
+        g.setColour(getColour(Styles::labelcolor));
         g.drawText(name, ht, juce::Justification::centredLeft);
         labelWidth = g.getCurrentFont().getStringWidth(name);
     }
 
-    g.setColour(getColour(Styles::labelrulecol));
+    g.setColour(getColour(Styles::labelrule));
     ht = b.withHeight(headerHeight);
 
     auto showHamburger = isEnabled() && hasHamburger;
@@ -206,7 +204,7 @@ void NamedPanel::mouseDown(const juce::MouseEvent &event)
 
 void NamedPanel::resetTabState()
 {
-    auto f = getFont(Styles::regionLabelFont);
+    auto f = getFont(Styles::labelfont);
 
     auto b = getLocalBounds().reduced(outerMargin);
     auto ht = b.withHeight(headerHeight).reduced(4, 0); // the extra margin

--- a/src/sst/jucegui/components/NamedPanelDivider.cpp
+++ b/src/sst/jucegui/components/NamedPanelDivider.cpp
@@ -27,7 +27,7 @@ NamedPanelDivider::~NamedPanelDivider() {}
 
 void NamedPanelDivider::paint(juce::Graphics &g)
 {
-    g.setColour(getColour(Styles::dividercol));
+    g.setColour(getColour(Styles::outline));
 
     auto divH = 2;
     auto margin = 10;

--- a/src/sst/jucegui/components/SevenSegmentControl.cpp
+++ b/src/sst/jucegui/components/SevenSegmentControl.cpp
@@ -69,34 +69,6 @@ void SevenSegmentControl::mouseUp(const juce::MouseEvent &e)
         isDragGesture = false;
         return;
     }
-
-    if (hasJogButtons)
-    {
-        // TODO don't copy this
-        auto bd = getLocalBounds().toFloat().withTrimmedRight(jogButtonWidth + 2);
-        auto jb =
-            getLocalBounds().toFloat().withWidth(jogButtonWidth).translated(bd.getWidth() + 1, 0);
-        auto bq = bd.withWidth(bd.getWidth() * 1.f / numDigits);
-        bq = bq.translated(bq.getWidth() * (numDigits - 1), 0);
-        jb = jb.withHeight(bq.getWidth() / SevenSegmentPainter::aspectRatio);
-
-        auto r1 = jb.withHeight(jb.getHeight() / 2);
-        if (r1.contains(e.x, e.y))
-        {
-            onBeginEdit();
-            data->jog(+1);
-            onEndEdit();
-            repaint();
-        }
-        r1 = r1.translated(0, r1.getHeight());
-        if (r1.contains(e.x, e.y))
-        {
-            onBeginEdit();
-            data->jog(-1);
-            onEndEdit();
-            repaint();
-        }
-    }
 }
 
 void SevenSegmentControl::paint(juce::Graphics &g)
@@ -105,15 +77,11 @@ void SevenSegmentControl::paint(juce::Graphics &g)
     if (data)
         val = data->getValue();
 
-    auto jbw = hasJogButtons ? jogButtonWidth : 0;
-
-    auto bd = getLocalBounds().toFloat().withTrimmedRight(jbw + 2 * hasJogButtons);
-    auto jb = getLocalBounds().toFloat().withWidth(jbw).translated(bd.getWidth() + 1, 0);
+    auto bd = getLocalBounds().toFloat();
     auto bq = bd.withWidth(bd.getWidth() * 1.f / numDigits);
-    jb = jb.withHeight(bq.getWidth() / SevenSegmentPainter::aspectRatio);
     auto pv = val;
-    auto lcol = getColour(Styles::controlLabelCol);
-    auto ocol = lcol.withAlpha(isHovered ? 0.2f : 0.1f);
+    auto lcol = isHovered ? getColour(Styles::labelcolor_hover) : getColour(Styles::labelcolor);
+    auto ocol = lcol.withAlpha(isHovered ? 0.15f : 0.1f);
 
     if (numDigits > 16)
     {
@@ -135,32 +103,6 @@ void SevenSegmentControl::paint(juce::Graphics &g)
         SevenSegmentPainter::paintInto(g, bq.reduced(0.5), (leadingZero ? ocol : lcol), ocol,
                                        digits[i]);
         bq = bq.translated(bq.getWidth(), 0);
-    }
-
-    if (hasJogButtons)
-    {
-        g.setColour(getColour(Styles::regionBorder));
-        g.drawRoundedRectangle(jb, 2, 1);
-        g.drawLine(jb.getX(), jb.getCentreY(), jb.getX() + jb.getWidth(), jb.getCentreY());
-
-        auto r1 = jb.withHeight(jb.getHeight() / 2);
-
-        if (isHovered && r1.contains(hoverX, hoverY))
-        {
-            g.setColour(getColour(Styles::regionBorder));
-            g.fillRoundedRectangle(r1, 2);
-        }
-        g.setColour(getColour(Styles::controlLabelCol));
-        GlyphPainter::paintGlyph(g, r1.toNearestInt(), GlyphPainter::JOG_UP);
-
-        r1 = r1.translated(0, r1.getHeight());
-        if (isHovered && r1.contains(hoverX, hoverY))
-        {
-            g.setColour(getColour(Styles::regionBorder));
-            g.fillRoundedRectangle(r1, 2);
-        }
-        g.setColour(getColour(Styles::controlLabelCol));
-        GlyphPainter::paintGlyph(g, r1.toNearestInt(), GlyphPainter::JOG_DOWN);
     }
 }
 } // namespace sst::jucegui::components

--- a/src/sst/jucegui/components/TabularizedTreeViewer.cpp
+++ b/src/sst/jucegui/components/TabularizedTreeViewer.cpp
@@ -35,8 +35,8 @@ void TabularizedTreeViewer::paint(juce::Graphics &g)
 
         g.setColour(juce::Colours::black);
         qr = qr.withTrimmedLeft(hotzoneSize + 4);
-        g.setFont(getFont(Styles::controlLabelFont));
-        g.setColour(getColour(Styles::controlLabelCol));
+        g.setFont(getFont(Styles::labelfont));
+        g.setColour(getColour(Styles::labelcolor));
         g.drawText(row.label, qr, juce::Justification::centredLeft);
 
         g.setColour(getColour(Styles::connectorcol));

--- a/src/sst/jucegui/components/TextPushButton.cpp
+++ b/src/sst/jucegui/components/TextPushButton.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "sst/jucegui/components/TextPushButton.h"
+#include "ButtonPainter.hxx"
 
 namespace sst::jucegui::components
 {
@@ -25,27 +26,12 @@ TextPushButton::~TextPushButton() {}
 
 void TextPushButton::paint(juce::Graphics &g)
 {
-    float rectCorner = 1.5;
-
-    auto b = getLocalBounds().reduced(1).toFloat();
-
-    auto bg = getColour(Styles::offbgcol);
-    auto fg = getColour(Styles::textoffcol);
-
-    if (isHovered)
-    {
-        bg = getColour(Styles::hoveronbgcol);
-        fg = getColour(Styles::texthoveroncol);
-    }
-
-    g.setColour(bg);
-    g.fillRoundedRectangle(b, rectCorner);
-
-    g.setColour(getColour(Styles::bordercol));
-    g.drawRoundedRectangle(b, rectCorner, 1);
-
+    paintButtonBG(this, g);
     g.setFont(getFont(Styles::labelfont));
-    g.setColour(fg);
-    g.drawText(label, b.withTrimmedLeft(2), juce::Justification::centred);
+    if (isHovered)
+        g.setColour(getColour(Styles::labelcolor_hover));
+    else
+        g.setColour(getColour(Styles::labelcolor));
+    g.drawText(label, getLocalBounds(), juce::Justification::centred);
 }
 } // namespace sst::jucegui::components

--- a/src/sst/jucegui/components/ToggleButton.cpp
+++ b/src/sst/jucegui/components/ToggleButton.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <sst/jucegui/components/ToggleButton.h>
+#include "ButtonPainter.hxx"
 
 namespace sst::jucegui::components
 {
@@ -24,64 +25,50 @@ ToggleButton::ToggleButton() : style::StyleConsumer(Styles::styleClass) {}
 ToggleButton::~ToggleButton()
 {
     if (data)
+    {
         data->removeGUIDataListener(this);
+    }
 }
 
 void ToggleButton::paint(juce::Graphics &g)
 {
-    float rectCorner = 1.5;
-
-    if (label.empty() && data)
-        label = data->getLabel();
-
-    auto b = getLocalBounds().reduced(1).toFloat();
     bool v = data ? data->getValue() : false;
 
-    auto bg = getColour(Styles::offbgcol);
-    auto fg = getColour(Styles::textoffcol);
     if (v)
     {
-        if (isHovered)
-        {
-            bg = getColour(Styles::hoveronbgcol);
-            fg = getColour(Styles::texthoveroncol);
-        }
-        else
-        {
-            bg = getColour(Styles::onbgcol);
-            fg = getColour(Styles::textoncol);
-        }
+        paintButtonOnValueBG(this, g);
     }
-    else if (isHovered)
+    else
     {
-        bg = getColour(Styles::hoveroffbgcol);
-        fg = getColour(Styles::texthoveroffcol);
+        paintButtonBG(this, g);
+    }
+
+    if (isHovered)
+    {
+        if (v)
+            g.setColour(getColour(Styles::valuelabel_hover));
+        else
+            g.setColour(getColour(Styles::labelcolor_hover));
+    }
+    else
+    {
+        if (v)
+            g.setColour(getColour(Styles::valuelabel));
+        else
+            g.setColour(getColour(Styles::labelcolor));
     }
 
     if (drawMode == DrawMode::GLYPH)
     {
-        if (v)
-            g.setColour(getColour(Styles::onbgcol));
-        else
-            g.setColour(getColour(Styles::onbgcol).withSaturation(0.2).withAlpha(0.5f));
         GlyphPainter::paintGlyph(g, getLocalBounds(), type);
         return;
     }
 
-    g.setColour(bg);
-    g.fillRoundedRectangle(b, rectCorner);
-
     if (drawMode == DrawMode::LABELED)
     {
         g.setFont(getFont(Styles::labelfont));
-        g.setColour(fg);
-        g.drawText(label, b, juce::Justification::centred);
+        g.drawText(label, getLocalBounds(), juce::Justification::centred);
     }
-    if (v)
-        g.setColour(getColour(Styles::borderoncol));
-    else
-        g.setColour(getColour(Styles::bordercol));
-    g.drawRoundedRectangle(b, rectCorner, 1);
 }
 
 void ToggleButton::mouseDown(const juce::MouseEvent &e) { onBeginEdit(); }

--- a/src/sst/jucegui/components/ToggleButtonRadioGroup.cpp
+++ b/src/sst/jucegui/components/ToggleButtonRadioGroup.cpp
@@ -46,7 +46,7 @@ struct subordinateDiscrete : data::Discrete
     void setValueFromModel(const int &f) override {}
 };
 
-ToggleButtonRadioGroup::ToggleButtonRadioGroup() : style::StyleConsumer(Styles::styleClass) {}
+ToggleButtonRadioGroup::ToggleButtonRadioGroup() {}
 
 ToggleButtonRadioGroup::~ToggleButtonRadioGroup()
 {
@@ -77,28 +77,34 @@ void ToggleButtonRadioGroup::resized()
 void ToggleButtonRadioGroup::dataChanged()
 {
     auto nBut = data ? (data->getMax() - data->getMin() + 1) : 0;
+
     if (!data || nBut != buttons.size())
     {
         for (const auto &b : buttons)
             removeChildComponent(b.get());
         buttons.clear();
         buttonSubData.clear();
-    }
-    if (!data)
-        return;
+        if (!data)
+            return;
 
-    for (int i = 0; i < nBut; ++i)
+        for (int i = 0; i < nBut; ++i)
+        {
+            auto b = std::make_unique<ToggleButton>();
+            b->setLabel(data->getValueAsStringFor(i));
+            addAndMakeVisible(*b);
+
+            auto sd = std::make_unique<subordinateDiscrete>(data, i);
+            b->setSource(sd.get());
+
+            buttons.push_back(std::move(b));
+            buttonSubData.push_back(std::move(sd));
+        }
+        resized();
+    }
+    else
     {
-        auto b = std::make_unique<ToggleButton>();
-        b->setLabel(data->getValueAsStringFor(i));
-        addAndMakeVisible(*b);
-
-        auto sd = std::make_unique<subordinateDiscrete>(data, i);
-        b->setSource(sd.get());
-
-        buttons.push_back(std::move(b));
-        buttonSubData.push_back(std::move(sd));
+        for (const auto &b : buttons)
+            b->dataChanged();
     }
-    resized();
 }
 } // namespace sst::jucegui::components

--- a/src/sst/jucegui/components/VSlider.cpp
+++ b/src/sst/jucegui/components/VSlider.cpp
@@ -44,10 +44,10 @@ void VSlider::paint(juce::Graphics &g)
                  .withTrimmedTop(hanRadius + 2)
                  .withTrimmedBottom(hanRadius + 2)
                  .toFloat();
-    g.setColour(getColour(Styles::backgroundcol));
+    g.setColour(getColour(Styles::outline));
     g.fillRoundedRectangle(r.reduced(1).toFloat(), gutterwidth * 0.25);
 
-    g.setColour(getColour(Styles::guttercol));
+    g.setColour(getColour(Styles::gutter));
     auto gutter = r.reduced(1).toFloat();
     g.fillRoundedRectangle(gutter.reduced(1), gutterwidth * 0.25);
 
@@ -56,18 +56,22 @@ void VSlider::paint(juce::Graphics &g)
 
     if (modulationDisplay == FROM_ACTIVE)
     {
-        g.setColour(getColour(Styles::modactivecol));
+        g.setColour(getColour(Styles::modulated_by_selected));
         g.fillRoundedRectangle(gutter.reduced(2), gutterwidth * 0.25);
     }
     else if (modulationDisplay == FROM_OTHER)
     {
-        g.setColour(getColour(Styles::modothercol));
+        g.setColour(getColour(Styles::modulated_by_other));
         g.fillRoundedRectangle(gutter.reduced(2), gutterwidth * 0.25);
     }
 
     auto v = continuous()->getValue01();
     auto h = (1.0 - v) * gutter.getHeight();
     auto hc = gutter.withTrimmedTop(h).withHeight(1).expanded(0, 4).getCentre();
+
+    auto valcol = getColour(Styles::value);
+    if (isHovered)
+        valcol = getColour(Styles::value_hover);
 
     if (continuous()->isBipolar())
     {
@@ -76,13 +80,13 @@ void VSlider::paint(juce::Graphics &g)
         if (t > b)
             std::swap(t, b);
         auto val = gutter.withTop(t).withBottom(b);
-        g.setColour(getColour(Styles::valcol));
+        g.setColour(valcol);
         g.fillRoundedRectangle(val, gutterwidth * 0.25);
     }
     else
     {
         auto val = gutter.withTrimmedTop(h);
-        g.setColour(getColour(Styles::valcol));
+        g.setColour(valcol);
         g.fillRoundedRectangle(val, gutterwidth * 0.25);
     }
 
@@ -90,7 +94,6 @@ void VSlider::paint(juce::Graphics &g)
 
     juce::Point<float> mpc;
     juce::Rectangle<float> mpr;
-
 
     if (continuousModulatable() && isEditingMod)
     {
@@ -100,6 +103,14 @@ void VSlider::paint(juce::Graphics &g)
         mpc = gutter.withTrimmedTop(hm).withHeight(1).expanded(0, 4).getCentre();
         mpr = juce::Rectangle<float>(2 * hanRadius, 2 * hanRadius).withCentre(mpc);
 
+        auto modvalcol = getColour(Styles::modulation_value);
+        if (isHovered)
+            modvalcol = getColour(Styles::modulation_value_hover);
+
+        auto modvaloppcol = getColour(Styles::modulation_opposite_value);
+        if (isHovered)
+            modvaloppcol = getColour(Styles::modulation_opposite_value_hover);
+
         // draw rules
         {
             auto t = hc.getY();
@@ -107,7 +118,7 @@ void VSlider::paint(juce::Graphics &g)
             if (t > b)
                 std::swap(t, b);
             auto val = gutter.withTop(t).withBottom(b).reduced(1, 0);
-            g.setColour(getColour(Styles::modvalcol));
+            g.setColour(modvalcol);
             g.fillRoundedRectangle(val, gutterwidth * 0.25);
         }
 
@@ -118,18 +129,27 @@ void VSlider::paint(juce::Graphics &g)
             if (t > b)
                 std::swap(t, b);
             auto val = gutter.withTop(t).withBottom(b).reduced(1, 0);
-            g.setColour(getColour(Styles::modvalnegcol));
+            g.setColour(modvaloppcol);
             g.fillRoundedRectangle(val, gutterwidth * 0.25);
         }
     }
-    g.setColour(getColour(Styles::handlecol));
+
+    if (isHovered)
+        g.setColour(getColour(Styles::handle_hover));
+    else
+        g.setColour(getColour(Styles::handle));
     g.fillEllipse(hr);
-    g.setColour(getColour(Styles::handlebordercol));
+    g.setColour(getColour(Styles::handle_outline));
     g.drawEllipse(hr, 0.5);
     if (isEditingMod)
     {
-        g.setColour(getColour(Styles::modhandlecol));
+        if (isHovered)
+            g.setColour(getColour(Styles::modulation_handle_hover));
+        else
+            g.setColour(getColour(Styles::modulation_handle));
         g.fillEllipse(mpr);
+        g.setColour(getColour(Styles::handle_outline));
+        g.drawEllipse(mpr, 1);
     }
 }
 


### PR DESCRIPTION
Major work on stylesheets in a couple of areas

1. Better factoring for the stylesheets themselves. We now mostly just use composition of base shetes with consistent names
2. Beter object model internally so we can do things like dump the sheet easily
3. Upgrade all the examples as I went

This is a non-compatible change, so I'll merge it, then I'll fix conduit, then I'll fix short circuit