### PR TITLE
Accessibility Support: Step 1

### DIFF
--- a/include/sst/jucegui/accessibility/Ignored.h
+++ b/include/sst/jucegui/accessibility/Ignored.h
@@ -1,0 +1,41 @@
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
+
+#ifndef INCLUDE_SST_JUCEGUI_ACCESSIBILITY_IGNORED_H
+#define INCLUDE_SST_JUCEGUI_ACCESSIBILITY_IGNORED_H
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+namespace sst::jucegui::accessibility
+{
+template <typename T> struct IgnoredMixin : public T
+{
+    std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override
+    {
+        return std::make_unique<juce::AccessibilityHandler>(*this,
+                                                            juce::AccessibilityRole::ignored);
+    }
+};
+
+struct IgnoredComponent : IgnoredMixin<juce::Component>
+{
+    IgnoredComponent() { setAccessible(true); }
+};
+
+} // namespace sst::jucegui::accessibility
+
+#endif // CONDUIT_IGNORED_H

--- a/include/sst/jucegui/components/CallbackButtonComponent.h
+++ b/include/sst/jucegui/components/CallbackButtonComponent.h
@@ -25,11 +25,21 @@ namespace sst::jucegui::components
 {
 template <typename T> struct CallbackButtonComponent : public juce::Component
 {
+    CallbackButtonComponent()
+    {
+        setAccessible(true);
+        setWantsKeyboardFocus(true);
+        setTitle("Unlabeled Callback Button");
+    }
     T *asT() { return static_cast<T *>(this); }
 
     void setOnCallback(const std::function<void()> &cb) { onCB = cb; }
 
-    void setLabel(const std::string &l) { label = l; }
+    void setLabel(const std::string &l)
+    {
+        label = l;
+        setTitle("Label");
+    }
     std::string getLabel() const { return label; }
 
     void mouseEnter(const juce::MouseEvent &e) override

--- a/include/sst/jucegui/components/ComponentBase.h
+++ b/include/sst/jucegui/components/ComponentBase.h
@@ -150,7 +150,10 @@ template <typename T> struct Modulatable : public data::Continuous::DataListener
             continuous()->removeGUIDataListener(this);
         source = s;
         if (continuous())
+        {
             continuous()->addGUIDataListener(this);
+            asT()->setTitle(continuous()->getLabel());
+        }
         asT()->repaint();
     }
 

--- a/include/sst/jucegui/components/DiscreteParamEditor.h
+++ b/include/sst/jucegui/components/DiscreteParamEditor.h
@@ -26,6 +26,11 @@ struct DiscreteParamEditor : public juce::Component,
                              public EditableComponentBase<DiscreteParamEditor>,
                              public data::Discrete::DataListener
 {
+    DiscreteParamEditor()
+    {
+        setAccessible(true);
+        setWantsKeyboardFocus(true);
+    }
     ~DiscreteParamEditor()
     {
         if (data)
@@ -43,7 +48,10 @@ struct DiscreteParamEditor : public juce::Component,
             data->removeGUIDataListener(this);
         data = d;
         if (data)
+        {
             data->addGUIDataListener(this);
+            setTitle(data->getLabel());
+        }
         repaint();
     }
 

--- a/include/sst/jucegui/components/Label.h
+++ b/include/sst/jucegui/components/Label.h
@@ -40,15 +40,21 @@ struct Label : public juce::Component, public style::StyleConsumer, public style
         }
     };
 
-    Label() : style::StyleConsumer(Styles::styleClass){};
+    Label() : style::StyleConsumer(Styles::styleClass) { setAccessible(true); };
     ~Label() = default;
 
     void setText(const std::string &s)
     {
         text = s;
+        setTitle(s);
         repaint();
     }
     std::string getText() const { return text; }
+
+    std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override
+    {
+        return std::make_unique<juce::AccessibilityHandler>(*this, juce::AccessibilityRole::label);
+    }
 
     juce::Justification justification{juce::Justification::centred};
     void setJustification(juce::Justification j)

--- a/include/sst/jucegui/components/NamedPanel.h
+++ b/include/sst/jucegui/components/NamedPanel.h
@@ -82,6 +82,8 @@ struct NamedPanel : public juce::Component,
     {
         juce::Component::setName(n);
         name = n.toStdString();
+        setTitle(name);
+        setDescription(name);
         repaint();
     }
 

--- a/include/sst/jucegui/components/WindowPanel.h
+++ b/include/sst/jucegui/components/WindowPanel.h
@@ -41,7 +41,7 @@ struct WindowPanel : public juce::Component,
         }
     };
 
-    WindowPanel() : style::StyleConsumer(Styles::styleClass) {}
+    WindowPanel() : style::StyleConsumer(Styles::styleClass) { setAccessible(true); }
     ~WindowPanel() = default;
 
     void paint(juce::Graphics &g) override

--- a/src/sst/jucegui/components/ContinuousParamEditor.cpp
+++ b/src/sst/jucegui/components/ContinuousParamEditor.cpp
@@ -19,7 +19,12 @@
 
 namespace sst::jucegui::components
 {
-ContinuousParamEditor::ContinuousParamEditor(Direction dir) : direction(dir) {}
+ContinuousParamEditor::ContinuousParamEditor(Direction dir) : direction(dir)
+{
+    setAccessible(true);
+    setWantsKeyboardFocus(true);
+    setTitle("UnNamed Continuous");
+}
 ContinuousParamEditor::~ContinuousParamEditor() = default;
 
 void ContinuousParamEditor::mouseDown(const juce::MouseEvent &e)

--- a/src/sst/jucegui/components/NamedPanel.cpp
+++ b/src/sst/jucegui/components/NamedPanel.cpp
@@ -26,6 +26,10 @@ namespace sst::jucegui::components
 NamedPanel::NamedPanel(const std::string &name)
     : style::StyleConsumer(Styles::styleClass), name(name)
 {
+    setAccessible(true);
+    setTitle(name);
+    setDescription(name);
+    setWantsKeyboardFocus(true);
 }
 
 NamedPanel::~NamedPanel() {}
@@ -243,6 +247,8 @@ void NamedPanel::setTogglable(bool b)
         {
             toggleButton = std::make_unique<ToggleButton>();
             toggleButton->setDrawMode(ToggleButton::DrawMode::FILLED);
+            toggleButton->setAccessible(true);
+            toggleButton->setTitle(name + " Toggle");
             addAndMakeVisible(*toggleButton);
         }
         resized();


### PR DESCRIPTION
This has the necessary changes so Conduit elements are at least labeled properly and light up, albeit always as groups, in the accessibility view. it also starts adding some of the utilities we need to get surge level accessibility here.