### PR TITLE
Continuous controls get Accessible setup

### DIFF
--- a/include/sst/jucegui/accessibility/AccessibilityConfiguration.h
+++ b/include/sst/jucegui/accessibility/AccessibilityConfiguration.h
@@ -1,0 +1,37 @@
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
+
+#ifndef INCLUDE_SST_JUCEGUI_ACCESSIBILITY_ACCESSIBILITYCONFIGURATION_H
+#define INCLUDE_SST_JUCEGUI_ACCESSIBILITY_ACCESSIBILITYCONFIGURATION_H
+
+#include <memory>
+
+namespace sst::jucegui::accessibility
+{
+struct AccessibilityConfiguration
+{
+    struct Provider
+    {
+        bool useKeyboardEdits{true};
+    };
+
+    // make this a shared pointer so multiple widges can have the same provider
+    std::shared_ptr<Provider> accessibilityConfiguration{std::make_shared<Provider>()};
+};
+} // namespace sst::jucegui::accessibility
+
+#endif // CONDUIT_ACCESSIBILITYCONFIGURATION_H

--- a/include/sst/jucegui/accessibility/AccessibilityKeyboardEdits.h
+++ b/include/sst/jucegui/accessibility/AccessibilityKeyboardEdits.h
@@ -1,0 +1,119 @@
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
+
+#ifndef INCLUDE_SST_JUCEGUI_ACCESSIBILITY_ACCESSIBILITYKEYBOARDEDITS_H
+#define INCLUDE_SST_JUCEGUI_ACCESSIBILITY_ACCESSIBILITYKEYBOARDEDITS_H
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "AccessibilityConfiguration.h"
+
+namespace sst::jucegui::accessibility
+{
+template <typename T> struct AccessibilityKeyboardEditSupport
+{
+    T *asT() { return static_cast<T *>(this); }
+
+    struct Action
+    {
+        enum AccessibleKeyEditAction
+        {
+            None,
+            Increase,
+            Decrease,
+            ToMax,
+            ToMin,
+            ToDefault,
+            OpenMenu,
+            OpenEditor
+        } action{None};
+
+        enum AccessibleKeyModifier
+        {
+            NoModifier,
+            Fine,
+            Quantized
+        } mod{NoModifier};
+
+        Action() {}
+        Action(AccessibleKeyEditAction a) : action(a), mod(NoModifier) {}
+        Action(AccessibleKeyEditAction a, AccessibleKeyModifier m) : action(a), mod(m) {}
+
+        bool isNone() const { return action == None; }
+    };
+
+    Action accessibleEdit(const juce::KeyPress &key)
+    {
+        if (!asT()->accessibilityConfiguration->useKeyboardEdits)
+        {
+            return {};
+        }
+
+        if (key.getKeyCode() == juce ::KeyPress::downKey)
+        {
+            if (key.getModifiers().isShiftDown())
+                return {Action::Decrease, Action::Fine};
+            if (key.getModifiers().isCommandDown())
+                return {Action::Decrease, Action::Quantized};
+            return {Action::Decrease};
+        }
+
+        if (key.getKeyCode() == juce ::KeyPress::upKey)
+        {
+            if (key.getModifiers().isShiftDown())
+                return {Action::Increase, Action::Fine};
+            if (key.getModifiers().isCommandDown())
+                return {Action::Increase, Action::Quantized};
+            return {Action::Increase};
+        }
+
+        if (key.getKeyCode() == juce::KeyPress::F10Key && key.getModifiers().isShiftDown())
+        {
+            return {Action::OpenMenu};
+        }
+
+        if (key.getKeyCode() == 93)
+        {
+            return {Action::OpenMenu};
+        }
+
+        if (key.getKeyCode() == juce::KeyPress::returnKey && key.getModifiers().isShiftDown())
+        {
+            return {Action::OpenEditor};
+        }
+
+        if (key.getKeyCode() == juce::KeyPress::homeKey)
+        {
+            return {Action::ToMax};
+        }
+
+        if (key.getKeyCode() == juce::KeyPress::endKey)
+        {
+            return {Action::ToMin};
+        }
+
+        if (key.getKeyCode() == juce::KeyPress::deleteKey)
+        {
+            return {Action::ToDefault};
+        }
+
+        return {};
+    }
+};
+} // namespace sst::jucegui::accessibility
+
+#endif // CONDUIT_ACCESIBILITYKEYBOARDEDITS_H

--- a/include/sst/jucegui/components/ContinuousParamEditor.h
+++ b/include/sst/jucegui/components/ContinuousParamEditor.h
@@ -27,13 +27,19 @@
 
 #include "ComponentBase.h"
 #include "BaseStyles.h"
+#include "sst/jucegui/accessibility/AccessibilityConfiguration.h"
+#include "sst/jucegui/accessibility/AccessibilityKeyboardEdits.h"
 
 namespace sst::jucegui::components
 {
-struct ContinuousParamEditor : public juce::Component,
-                               public Modulatable<ContinuousParamEditor>,
-                               public EditableComponentBase<ContinuousParamEditor>,
-                               public style::SettingsConsumer
+struct ContinuousParamEditor
+    : public juce::Component,
+      public Modulatable<ContinuousParamEditor>,
+      public EditableComponentBase<ContinuousParamEditor>,
+      public style::SettingsConsumer,
+      public sst::jucegui::accessibility::AccessibilityConfiguration,
+      public sst::jucegui::accessibility::AccessibilityKeyboardEditSupport<ContinuousParamEditor>
+
 {
     struct Styles : base_styles::ValueBearing,
                     base_styles::ModulationValueBearing,
@@ -82,6 +88,14 @@ struct ContinuousParamEditor : public juce::Component,
     void mouseEnter(const juce::MouseEvent &e) override { startHover(); }
     void mouseExit(const juce::MouseEvent &e) override { endHover(); }
     void mouseMove(const juce::MouseEvent &e) override { resetTimer(e); }
+
+    bool keyPressed(const juce::KeyPress &k) override;
+
+    void focusGained(juce::Component::FocusChangeType cause) override { startHover(); }
+    void focusLost(juce::Component::FocusChangeType cause) override { endHover(); }
+
+    std::unique_ptr<juce::AccessibilityHandler> createAccessibilityHandler() override;
+    void notifyAccessibleChange();
 
   protected:
     float mouseDownV0, mouseDownX0, mouseDownY0;

--- a/include/sst/jucegui/data/Continuous.h
+++ b/include/sst/jucegui/data/Continuous.h
@@ -77,14 +77,16 @@ struct Continuous : public Labeled
 
     virtual float getMin() const { return 0; }
     virtual float getMax() const { return 1; }
-    virtual float getQuantizedStepSize() const { return (getMax() - getMin()) / 10.0; }
-    virtual float getFineQuantizedStepSize() const { return 0.1 * getQuantizedStepSize(); }
+    virtual float getMinMaxRange() const { return getMax() - getMin(); }
+    virtual float getQuantizedStepSize() { return getMinMaxRange() / 10.f; }
 
     virtual bool isBipolar() const { return getMin() < 0 && getMax() > 0; }
 
-    virtual void jog(int dir)
+    virtual float quantizeValue(float val)
     {
-        setValueFromGUI(std::clamp(getValue() + dir * getQuantizedStepSize(), getMin(), getMax()));
+        auto qs = (getMax() - getMin()) / 10.f;
+        float qval = std::clamp(qs * (int)std::round(val / qs), getMin(), getMax());
+        return qval;
     }
 
   protected:

--- a/src/sst/jucegui/components/DraggableTextEditableValue.cpp
+++ b/src/sst/jucegui/components/DraggableTextEditableValue.cpp
@@ -87,7 +87,7 @@ void DraggableTextEditableValue::mouseDrag(const juce::MouseEvent &e)
 {
     auto d = e.getDistanceFromDragStartY();
     auto fac = 0.5f * (e.mods.isShiftDown() ? 0.1f : 1.f);
-    auto nv = valueOnMouseDown - fac * d * continuous()->getFineQuantizedStepSize();
+    auto nv = valueOnMouseDown - fac * d * continuous()->getMinMaxRange() * 0.01f;
     nv = std::clamp(nv, continuous()->getMin(), continuous()->getMax());
     continuous()->setValueFromGUI(nv);
     repaint();


### PR DESCRIPTION
The ContinuousParamEditor subclasses get a first-blush accessibility implementation for the non-modulated case with events, a handler, etc...