### PR TITLE
WithIdleTimer destructor cleanup

### DIFF
--- a/src/sst/jucegui/components/ComponentBase.cpp
+++ b/src/sst/jucegui/components/ComponentBase.cpp
@@ -54,6 +54,12 @@ WithIdleTimer::WithIdleTimer()
 }
 WithIdleTimer::~WithIdleTimer()
 {
+    auto ct = WithIdleTimer::registeredItems.find(this);
+    if (ct != WithIdleTimer::registeredItems.end())
+    {
+        // delete while hovered or whatnot
+        WithIdleTimer::registeredItems.erase(ct);
+    }
     timerClients--;
     if (timerClients == 0)
     {


### PR DESCRIPTION
If an object was hovered / idle timered while deleted it would crash. This would casue, for instance, group add errors in SCXT.

Clean up by safeul removing self in destructor of interface