### PR TITLE
JuceGUI changes towards the SCXT Figma Themes

### DIFF
--- a/include/sst/jucegui/components/NamedPanel.h
+++ b/include/sst/jucegui/components/NamedPanel.h
@@ -63,6 +63,7 @@ struct NamedPanel : public juce::Component,
     ~NamedPanel();
 
     void paint(juce::Graphics &g) override;
+    void paintOverChildren(juce::Graphics &g) override;
     void resized() override;
 
     juce::Rectangle<int> getContentArea();
@@ -136,11 +137,21 @@ struct NamedPanel : public juce::Component,
             resized();
     }
 
+    /*
+     * activate position debugging overlays. Starts a timer.
+     * Almost definitely don't want in release code!
+     */
+    void activatePositionDebugging(bool enable);
+    void doPositionDebugActions();
+    juce::Component::SafePointer<juce::Component> debugComponent{nullptr};
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(NamedPanel)
 
   protected:
     std::string name;
     std::unique_ptr<juce::Component> contentAreaComp;
+
+    std::unique_ptr<juce::Timer> positionDebugTimer;
 };
 } // namespace sst::jucegui::components
 

--- a/include/sst/jucegui/components/WindowPanel.h
+++ b/include/sst/jucegui/components/WindowPanel.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <sst/jucegui/style/StyleAndSettingsConsumer.h>
 #include <sst/jucegui/style/StyleSheet.h>
+#include "BaseStyles.h"
 
 namespace sst::jucegui::components
 {

--- a/include/sst/jucegui/style/CustomizationTools.h
+++ b/include/sst/jucegui/style/CustomizationTools.h
@@ -1,0 +1,81 @@
+/*
+ * sst-juce-gui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-basic-blocks is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-juce-gui available at
+ * https://github.com/surge-synthesizer/sst-juce-gui
+ */
+
+#ifndef INCLUDE_SST_JUCEGUI_STYLE_CUSTOMIZATIONTOOLS_H
+#define INCLUDE_SST_JUCEGUI_STYLE_CUSTOMIZATIONTOOLS_H
+
+#include "StyleAndSettingsConsumer.h"
+
+namespace sst::jucegui::style
+{
+struct Traverser
+{
+    /*
+     * Given a component travers its children recursively calling
+     * the consumer function for each style consumer. If the function
+     * returns true, continue descent into its children. If the
+     * from component is a style consumer, call the function on it also.
+     */
+    void forStyleParticpants(juce::Component *from, std::function<bool(StyleConsumer *)> consumer)
+    {
+        bool continueDescent{true};
+        auto asSC = dynamic_cast<StyleConsumer *>(from);
+        if (asSC && consumer)
+        {
+            continueDescent = consumer(asSC);
+        }
+        if (continueDescent)
+        {
+            for (auto &k : from->getChildren())
+            {
+                forStyleParticpants(k, consumer);
+            }
+        }
+    }
+};
+
+struct CustomTypeMap
+{
+    std::vector<std::function<bool(StyleConsumer *)>> remappers;
+    template <typename Under> void addCustomClass(const StyleSheet::Class &cl)
+    {
+        remappers.push_back([&cl](StyleConsumer *c) -> bool {
+            auto *asUnder = dynamic_cast<Under *>(c);
+            if (asUnder)
+            {
+                c->setCustomClass(cl);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    void applyMapTo(juce::Component *c)
+    {
+        Traverser t;
+        t.forStyleParticpants(c, [this](auto *target) {
+            for (auto &m : remappers)
+            {
+                if (m(target))
+                    break;
+            }
+            return true;
+        });
+    }
+};
+} // namespace sst::jucegui::style
+#endif // SHORTCIRCUITXT_TRAVERSER_H

--- a/include/sst/jucegui/style/StyleAndSettingsConsumer.h
+++ b/include/sst/jucegui/style/StyleAndSettingsConsumer.h
@@ -45,7 +45,7 @@ struct StyleConsumer
     {
         if (style())
             return style()->getFont(getStyleClass(), p);
-        return juce::Font(1);
+        return {1};
     }
 
     // these don't belong on instances they belong on stylesheets
@@ -53,7 +53,7 @@ struct StyleConsumer
     void setCustomClass(const StyleSheet::Class &sc)
     {
         customClass.copyFrom(sc);
-        StyleSheet::extendInheritanceMap(customClass, styleClass);
+        onStyleChanged();
     }
 
     void removeCustomClass() { customClass.cname[0] = 0; }
@@ -139,4 +139,4 @@ struct SettingsConsumer
 };
 } // namespace sst::jucegui::style
 
-#endif // SST_JUCEGUI_STYLEANDSETTINGSCONSUMER_H
+#endif // INCLUDE_SST_JUCEGUI_STYLE_STYLEANDSETTINGSCONSUMER_H

--- a/include/sst/jucegui/style/StyleSheet.h
+++ b/include/sst/jucegui/style/StyleSheet.h
@@ -133,10 +133,13 @@ struct StyleSheet
 
     virtual bool hasColour(const Class &c, const Property &p) const = 0;
     virtual juce::Colour getColour(const Class &c, const Property &p) const = 0;
+    virtual std::optional<juce::Colour> getColourOptional(const Class &c,
+                                                          const Property &p) const = 0;
     virtual void setColour(const Class &c, const Property &p, const juce::Colour &) = 0;
 
     virtual bool hasFont(const Class &c, const Property &p) const = 0;
     virtual juce::Font getFont(const Class &c, const Property &p) const = 0;
+    virtual std::optional<juce::Font> getFontOptional(const Class &c, const Property &p) const = 0;
     virtual void setFont(const Class &c, const Property &p, const juce::Font &) = 0;
 
     virtual void replaceFontsWithTypeface(const juce::Typeface::Ptr &p) = 0;
@@ -147,7 +150,8 @@ struct StyleSheet
     enum BuiltInTypes
     {
         DARK,
-        LIGHT
+        LIGHT,
+        EMPTY
     };
     static ptr_t getBuiltInStyleSheet(const BuiltInTypes &t);
 

--- a/src/sst/jucegui/components/KnobPainter.hxx
+++ b/src/sst/jucegui/components/KnobPainter.hxx
@@ -5,14 +5,113 @@
 #ifndef CONDUIT_KNOBPAINTER_H
 #define CONDUIT_KNOBPAINTER_H
 
-#include <juce_gui_basics/juce_gui_basics.h>
 #include <type_traits>
+#include <algorithm>
+
+#include <juce_gui_basics/juce_gui_basics.h>
 
 namespace sst::jucegui::components
 {
+
+template <typename T, typename S> void knobPainterNoBody(juce::Graphics &g, T *that, S *source)
+{
+    auto b = that->getLocalBounds();
+    auto knobarea = b.withHeight(b.getWidth());
+
+    int strokeWidth{5};
+    if (knobarea.getWidth() < 20)
+        strokeWidth = 3;
+
+    //  start and end here are 0...1
+    auto arcFromTo = [knobarea, strokeWidth](float startV, float endV) {
+        float dPath = 0.2;
+        float dAng = juce::MathConstants<float>::pi * (1 - dPath);
+        float startA = dAng * (2 * startV - 1);
+        float endA = dAng * (2 * endV - 1);
+
+        auto region = knobarea.toFloat().reduced(strokeWidth * 0.5 + 1);
+        auto p = juce::Path();
+        p.startNewSubPath(region.getCentre().toFloat());
+        p.addArc(region.getX(), region.getY(), region.getWidth(), region.getHeight(), startA, endA,
+                 true);
+        return p;
+    };
+
+    if (that->isHovered)
+        g.setColour(that->getColour(T::Styles::gutter_hover));
+    else
+        g.setColour(that->getColour(T::Styles::gutter));
+    g.strokePath(arcFromTo(0, 1), juce::PathStrokeType(strokeWidth));
+
+    auto v = source->getValue01();
+    float startV{0.f}, endV{v};
+    switch (that->pathDrawMode)
+    {
+    case T::FOLLOW_BIPOLAR:
+        if (source->isBipolar())
+        {
+            startV = 0.5;
+        }
+        break;
+    case T::ALWAYS_FROM_MIN:
+        break;
+    case T::ALWAYS_FROM_MAX:
+    {
+        startV = 1.f;
+    }
+    break;
+    case T::ALWAYS_FROM_DEFAULT:
+    {
+        startV =
+            (source->getDefaultValue() - source->getMin()) / (source->getMax() - source->getMin());
+    }
+    break;
+    }
+    if (startV > endV)
+        std::swap(startV, endV);
+
+    if (that->isHovered)
+        g.setColour(that->getColour(T::Styles::value_hover));
+    else
+        g.setColour(that->getColour(T::Styles::value));
+    g.strokePath(arcFromTo(startV, endV), juce::PathStrokeType(strokeWidth));
+
+    constexpr bool supportsMod = std::is_base_of_v<data::ContinuousModulatable, S>;
+
+    if constexpr (supportsMod)
+    {
+        if (that->isEditingMod)
+        {
+            auto mstart = source->getValue01();
+            auto mend = std::clamp(mstart + source->getModulationValuePM1(), 0.f, 1.f);
+
+            if (mstart > mend)
+                std::swap(mstart, mend);
+            g.setColour(that->getColour(T::Styles::modulation_value));
+            g.strokePath(arcFromTo(mstart, mend), juce::PathStrokeType(strokeWidth * 0.7));
+
+            if (source->isModulationBipolar())
+            {
+                auto mstart = source->getValue01();
+                auto mend = std::clamp(mstart - source->getModulationValuePM1(), 0.f, 1.f);
+
+                if (mstart > mend)
+                    std::swap(mstart, mend);
+                g.setColour(that->getColour(T::Styles::modulation_value));
+                g.strokePath(arcFromTo(mstart, mend), juce::PathStrokeType(strokeWidth * 0.7));
+            }
+        }
+    }
+
+    if (that->isHovered)
+    {
+        auto v = source->getValue01();
+        g.setColour(that->getColour(T::Styles::handle));
+        g.strokePath(arcFromTo(v - 0.005, v + 0.005), juce::PathStrokeType(strokeWidth));
+    }
+}
 template <typename T, typename S> void knobPainter(juce::Graphics &g, T *that, S *source)
 {
-    constexpr bool supportsMod = std::is_base_of_v<data::ContinuousModulatable, S>;
 
     if (!source)
     {
@@ -23,17 +122,16 @@ template <typename T, typename S> void knobPainter(juce::Graphics &g, T *that, S
 
     auto knobarea = b.withHeight(b.getWidth());
 
-    auto pacman = [knobarea](float r, float ddPath = 0) -> juce::Path {
-        float dPath = 0.2 + ddPath;
-        auto region = knobarea.toFloat().reduced(r);
-        auto p = juce::Path();
-        p.startNewSubPath(region.getCentre().toFloat());
-        p.addArc(region.getX(), region.getY(), region.getWidth(), region.getHeight(),
-                 juce::MathConstants<float>::pi * (1 - dPath),
-                 -juce::MathConstants<float>::pi * (1 - dPath));
-        p.closeSubPath();
-        return p;
-    };
+    auto kbcol = that->getColour(T::Styles::knobbase);
+    knobPainterNoBody(g, that, source);
+
+    int strokeWidth{5};
+    bool smallKnob = false;
+    if (knobarea.getWidth() < 20)
+    {
+        smallKnob = true;
+        strokeWidth = 3;
+    }
 
     auto circle = [knobarea](float r) -> juce::Path {
         auto region = knobarea.toFloat().reduced(r);
@@ -45,202 +143,84 @@ template <typename T, typename S> void knobPainter(juce::Graphics &g, T *that, S
         return p;
     };
 
-    auto pathWithReduction = [that, source, knobarea](float r, float v) -> juce::Path {
-        float dPath = 0.2;
-        float dAng = juce::MathConstants<float>::pi * (1 - dPath);
-        float start = dAng * (2 * v - 1); // 1 -> dAng; 0 -> -dAng so dAng * 2 * v - dAng
-        float end = -dAng;
-        switch (that->pathDrawMode)
-        {
-        case T::FOLLOW_BIPOLAR:
-            if (source->isBipolar())
-            {
-                auto v0 = v;
-                v = 2 * v - 1;
-                // split between dAng and -dAnd
-                float zero01 = (0 - source->getMin()) / (source->getMax() - source->getMin());
-                // 1 -> dAng; 0 -> -dAng again so
-                start = dAng * (2 * zero01 - 1);
-                end = dAng * v;
-            }
-            break;
-        case T::ALWAYS_FROM_MIN:
-            break;
-        case T::ALWAYS_FROM_MAX:
-        {
-            auto t = start;
-            start = dAng;
-            end = t;
-        }
-        break;
-        case T::ALWAYS_FROM_DEFAULT:
-        {
-            auto v0 = v;
-            v = 2 * v - 1;
-            // split between dAng and -dAnd
-            float zero01 = (source->getDefaultValue() - source->getMin()) /
-                           (source->getMax() - source->getMin());
-            // 1 -> dAng; 0 -> -dAng again so
-            start = dAng * (2 * zero01 - 1);
-            end = dAng * v;
-        }
-        break;
-        }
-        auto region = knobarea.toFloat().reduced(r);
-        auto p = juce::Path();
-        p.startNewSubPath(region.getCentre().toFloat());
-        p.addArc(region.getX(), region.getY(), region.getWidth(), region.getHeight(), start, end);
-        p.closeSubPath();
-        return p;
-    };
-
-    auto handlePath = [that, knobarea](int r, float v) -> juce::Path {
-        float dPath = 0.2;
-        float dAng = juce::MathConstants<float>::pi * (1 - dPath);
-        float pt = dAng * (2 * v - 1);
-        auto start = pt - juce::MathConstants<float>::pi * 0.02;
-        auto end = pt + juce::MathConstants<float>::pi * 0.02;
-        auto region = knobarea.reduced(r);
-        auto p = juce::Path();
-        p.startNewSubPath(region.getCentre().toFloat());
-        p.addArc(region.getX(), region.getY(), region.getWidth(), region.getHeight(), start, end);
-        p.closeSubPath();
-        return p;
-    };
-
-    auto handleAngle = [that, knobarea](float v) -> float {
-        float dPath = 0.2;
-        float dAng = juce::MathConstants<float>::pi * (1 - dPath);
-        float pt = dAng * (2 * v - 1);
-        return pt;
-    };
-
-    auto modPath = [that, knobarea](float r, float v, float m, int direction) -> juce::Path {
-        float dPath = 0.2;
-        float dAng = juce::MathConstants<float>::pi * (1 - dPath);
-        float pt = dAng * (2 * v - 1);
-        auto start = pt;
-        auto end = pt + direction * dAng * 2 * m;
-        start = std::clamp(start, -dAng, dAng);
-        end = std::clamp(end, -dAng, dAng);
-        auto region = knobarea.toFloat().reduced(r);
-        auto p = juce::Path();
-        p.startNewSubPath(region.getCentre().toFloat());
-        p.addArc(region.getX(), region.getY(), region.getWidth(), region.getHeight(), start, end);
-        p.closeSubPath();
-        return p;
-    };
-
-    static constexpr float gutterPad{1};
-    // outer gutter edge
-    auto pOut = pacman(0, -0.005);
-    g.setColour(that->getColour(T::Styles::background));
-    g.fillPath(pOut);
-
-    // inner gutter
-    auto pIn = pacman(gutterPad);
-    g.setColour(that->getColour(T::Styles::gutter));
-    g.fillPath(pIn);
-
-    // value gutter
-    pIn = pathWithReduction(gutterPad * 1.5, source->getValue01());
-    if (that->isHovered)
-        g.setColour(that->getColour(T::Styles::value_hover));
-    else
-        g.setColour(that->getColour(T::Styles::value));
-    g.fillPath(pIn);
-
-    // modulation arcs
-    if constexpr (supportsMod)
+    if (kbcol.getAlpha() != 0)
     {
-        if (that->isEditingMod)
+        auto handleAngle = [that, knobarea](float v) -> float {
+            float dPath = 0.2;
+            float dAng = juce::MathConstants<float>::pi * (1 - dPath);
+            float pt = dAng * (2 * v - 1);
+            return pt;
+        };
+
+        // Fill over the mess in the middle
+        auto c = that->getColour(T::Styles::knobbase);
+
+        auto makeGrad = [c, knobarea](auto up, auto dn) {
+            return juce::ColourGradient::vertical(c.brighter(up), knobarea.getY(), c.darker(dn),
+                                                  knobarea.getY() + knobarea.getHeight());
+        };
+        g.saveState();
+        g.addTransform(juce::AffineTransform()
+                           .translated(-knobarea.getWidth() / 2, -knobarea.getHeight() / 2)
+                           .rotated(-0.3)
+                           .translated(knobarea.getWidth() / 2, knobarea.getHeight() / 2));
+
+        auto pIn = circle(strokeWidth);
+        g.setGradientFill(makeGrad(0.0, 0.5));
+        g.fillPath(pIn);
+        g.setColour(c.darker(0.6));
+        g.strokePath(pIn, juce::PathStrokeType(smallKnob ? 0.5 : 1.0));
+
+        pIn = circle(strokeWidth + 1);
+        g.setGradientFill(makeGrad(0.6, 0.35));
+        g.fillPath(pIn);
+
+        pIn = circle(strokeWidth + 2);
+        g.setGradientFill(makeGrad(0.1, 0.05));
+        g.fillPath(pIn);
+
+        g.restoreState();
+
+        g.saveState();
+        g.addTransform(juce::AffineTransform()
+                           .translated(-knobarea.getWidth() / 2, -knobarea.getHeight() / 2)
+                           .rotated(handleAngle(source->getValue01()))
+                           .translated(knobarea.getWidth() / 2, knobarea.getHeight() / 2));
+
+        auto hanWidth = 2.f;
+        auto hanLen = smallKnob ? 3.f : 8.f;
+        auto hanRect = juce::Rectangle<float>(knobarea.getWidth() / 2.f - hanWidth / 2.f,
+                                              strokeWidth, hanWidth, hanLen);
+
+        if (that->isHovered)
         {
-            pIn = modPath(gutterPad * 2, source->getValue01(), source->getModulationValuePM1(), 1);
-            g.setColour(that->getColour(T::Styles::modulation_value));
-            g.fillPath(pIn);
-            if (source->isModulationBipolar())
-            {
-                pIn = modPath(gutterPad * 2, source->getValue01(), source->getModulationValuePM1(),
-                              -1);
-                g.setColour(that->getColour(T::Styles::modulation_opposite_value));
-                g.fillPath(pIn);
-            }
+            g.setColour(that->getColour(T::Styles::handle));
+            g.fillRect(hanRect);
         }
+        else
+        {
+            g.setColour(that->getColour(T::Styles::handle).withAlpha(0.2f));
+            g.fillRect(hanRect);
+            g.setColour(that->getColour(T::Styles::handle).withAlpha(0.4f));
+            g.drawRect(hanRect, 0.5);
+        }
+
+        g.restoreState();
     }
-
-    auto knobSize = gutterPad * 5.f;
-    bool smallKnob = false;
-    if (knobSize > knobarea.getWidth() * .15)
-    {
-        knobSize = gutterPad * 3.5;
-        smallKnob = true;
-    }
-    // Fill over the mess in the middle
-    auto c = that->getColour(T::Styles::knobbase);
-
-    auto makeGrad = [c, knobarea](auto up, auto dn) {
-        return juce::ColourGradient::vertical(c.brighter(up), knobarea.getY(), c.darker(dn),
-                                              knobarea.getY() + knobarea.getHeight());
-    };
-    g.saveState();
-    g.addTransform(juce::AffineTransform()
-                       .translated(-knobarea.getWidth() / 2, -knobarea.getHeight() / 2)
-                       .rotated(-0.3)
-                       .translated(knobarea.getWidth() / 2, knobarea.getHeight() / 2));
-
-    pIn = circle(knobSize);
-    g.setGradientFill(makeGrad(0.0, 0.5));
-    g.fillPath(pIn);
-    g.setColour(c.darker(0.6));
-    g.strokePath(pIn, juce::PathStrokeType(smallKnob ? 0.5 : 1.0));
-
-    pIn = circle(knobSize + gutterPad);
-    g.setGradientFill(makeGrad(0.6, 0.35));
-    g.fillPath(pIn);
-
-    pIn = circle(knobSize + 3 * gutterPad);
-    g.setGradientFill(makeGrad(0.1, 0.05));
-    g.fillPath(pIn);
-    g.restoreState();
-
-    g.saveState();
-    g.addTransform(juce::AffineTransform()
-                       .translated(-knobarea.getWidth() / 2, -knobarea.getHeight() / 2)
-                       .rotated(handleAngle(source->getValue01()))
-                       .translated(knobarea.getWidth() / 2, knobarea.getHeight() / 2));
-
-    auto hanWidth = 2.f;
-    auto hanRect =
-        juce::Rectangle<float>(knobarea.getWidth() / 2.f - hanWidth / 2.f, knobSize + gutterPad,
-                               hanWidth, smallKnob ? gutterPad * 5 : gutterPad * 10);
-
-    if (that->isHovered)
-    {
-        g.setColour(that->getColour(T::Styles::handle));
-        g.fillRect(hanRect);
-    }
-    else
-    {
-        g.setColour(that->getColour(T::Styles::handle).withAlpha(0.2f));
-        g.fillRect(hanRect);
-        g.setColour(that->getColour(T::Styles::handle).withAlpha(0.4f));
-        g.drawRect(hanRect, 0.5);
-    }
-
-    g.restoreState();
 
     if (that->modulationDisplay == ContinuousParamEditor::FROM_ACTIVE)
     {
-        pOut = circle(knobarea.getWidth() / 2 - (smallKnob ? 3 : 5));
+        auto pOut = circle(knobarea.getWidth() / 2 - (smallKnob ? 3 : 5));
         g.setColour(that->getColour(T::Styles::modulated_by_selected));
         g.fillPath(pOut);
     }
     if (that->modulationDisplay == ContinuousParamEditor::FROM_OTHER)
     {
-        pOut = circle(knobarea.getWidth() / 2 - (smallKnob ? 3 : 8));
+        auto pOut = circle(knobarea.getWidth() / 2 - (smallKnob ? 3 : 8));
         g.setColour(that->getColour(T::Styles::modulated_by_other));
         g.fillPath(pOut);
     }
 }
+
 } // namespace sst::jucegui::components
 #endif // CONDUIT_KNOBPAINTER_H

--- a/src/sst/jucegui/components/NamedPanel.cpp
+++ b/src/sst/jucegui/components/NamedPanel.cpp
@@ -32,7 +32,14 @@ NamedPanel::NamedPanel(const std::string &name)
     setWantsKeyboardFocus(true);
 }
 
-NamedPanel::~NamedPanel() {}
+NamedPanel::~NamedPanel()
+{
+    if (positionDebugTimer)
+    {
+        positionDebugTimer->stopTimer();
+        positionDebugTimer.reset();
+    }
+}
 
 void NamedPanel::paint(juce::Graphics &g)
 {
@@ -268,5 +275,123 @@ void NamedPanel::setToggleDataSource(data::Discrete *d)
     assert(isTogglable);
     assert(toggleButton);
     toggleButton->setSource(d);
+}
+
+struct PositionDebugTimerImpl : juce::Timer
+{
+    NamedPanel *that{nullptr};
+    PositionDebugTimerImpl(NamedPanel *p) : that(p) {}
+
+    void timerCallback() override { that->doPositionDebugActions(); }
+};
+
+void NamedPanel::doPositionDebugActions()
+{
+    auto psn = getMouseXYRelative();
+    if (contains(psn))
+    {
+        auto cmp = getComponentAt(psn);
+        if (cmp && cmp != debugComponent)
+        {
+            debugComponent = juce::Component::SafePointer(cmp);
+            repaint();
+        }
+    }
+    else
+    {
+        if (debugComponent)
+        {
+            debugComponent = nullptr;
+            repaint();
+        }
+    }
+}
+
+void NamedPanel::paintOverChildren(juce::Graphics &g)
+{
+    if (!positionDebugTimer)
+        return;
+    if (!debugComponent)
+        return;
+
+    if (debugComponent == this)
+    {
+        g.setColour(juce::Colours::yellow);
+        g.drawRect(getLocalBounds(), 1);
+        // TODO : Paint position in ultimate top level
+        return;
+    }
+
+    auto bn = debugComponent->getBounds();
+    auto tpn = debugComponent->getParentComponent();
+    while (tpn && tpn != this)
+    {
+        auto tb = tpn->getBounds();
+        bn = bn.translated(tb.getX(), tb.getY());
+        tpn = tpn->getParentComponent();
+    }
+
+    g.setColour(juce::Colours::red);
+
+    g.drawRect(bn, 1);
+    auto cx = bn.getCentreX();
+    auto cy = bn.getCentreY();
+    g.drawLine(0, cy, bn.getX(), cy, 1);
+    g.drawLine(cx, 0, cx, bn.getY());
+
+    g.setFont(getFont(Styles::labelfont).withHeight(10));
+    g.setColour(juce::Colours::red);
+    g.drawText(juce::String(bn.getX()), 0, cy - 12, bn.getX(), 12, juce::Justification::centred);
+    g.drawText(juce::String(bn.getY()), cx + 2, 0, 20, bn.getY(), juce::Justification::centredLeft);
+
+    g.setFont(getFont(Styles::labelfont).withHeight(10));
+    auto szRect = juce::Rectangle<int>(bn.getRight(), bn.getBottom() - 15, 40, 15);
+    auto psRect = juce::Rectangle<int>(bn.getRight(), bn.getY(), 40, 15);
+    if (bn.getCentreX() > getWidth() / 2)
+    {
+        szRect = szRect.translated(-szRect.getWidth() - bn.getWidth(), 0);
+        psRect = psRect.translated(-szRect.getWidth() - bn.getWidth(), 0);
+    }
+    if (szRect.intersects(psRect))
+    {
+        auto is = szRect.getIntersection(psRect);
+        szRect = szRect.translated(0, is.getHeight() / 2 + 1);
+        psRect = psRect.translated(0, -(is.getHeight() / 2 + 1));
+    }
+    g.setColour(juce::Colours::red.withAlpha(0.8f));
+    g.fillRect(szRect);
+    g.setColour(juce::Colours::red);
+    g.drawRect(szRect, 1);
+    g.setColour(juce::Colours::white);
+    g.drawText(juce::String(bn.getWidth()) + " x " + juce::String(bn.getHeight()), szRect,
+               juce::Justification::centred);
+
+    g.setColour(juce::Colours::red.withAlpha(0.8f));
+    g.fillRect(psRect);
+    g.setColour(juce::Colours::red);
+    g.drawRect(psRect, 1);
+    g.setColour(juce::Colours::white);
+    g.drawText(juce::String("@ ") + juce::String(bn.getX()) + "," + juce::String(bn.getY()), psRect,
+               juce::Justification::centred);
+}
+
+void NamedPanel::activatePositionDebugging(bool enable)
+{
+    if (enable)
+    {
+        if (!positionDebugTimer)
+        {
+            positionDebugTimer = std::make_unique<PositionDebugTimerImpl>(this);
+            positionDebugTimer->startTimer(100);
+        }
+    }
+    else
+    {
+        if (positionDebugTimer)
+        {
+            positionDebugTimer->stopTimer();
+            positionDebugTimer.reset();
+        }
+    }
 }
 } // namespace sst::jucegui::components

--- a/src/sst/jucegui/components/VSlider.cpp
+++ b/src/sst/jucegui/components/VSlider.cpp
@@ -48,6 +48,8 @@ void VSlider::paint(juce::Graphics &g)
     g.fillRoundedRectangle(r.reduced(1).toFloat(), gutterwidth * 0.25);
 
     g.setColour(getColour(Styles::gutter));
+    if (isHovered)
+        g.setColour(getColour(Styles::gutter_hover));
     auto gutter = r.reduced(1).toFloat();
     g.fillRoundedRectangle(gutter.reduced(1), gutterwidth * 0.25);
 


### PR DESCRIPTION
- Add the CustomizationTools to make custom styles easier
- Add the position debugger to the named panel
- More work on figma ui matching, including optional transparent knobs
- Styleshee Mechanics Cleanups
- Plenty of other little tweaks here and there