### PR TITLE
ParamMenuBulder can do menu order jog. JogMenu uses it

### DIFF
--- a/include/sst/jucegui/components/DiscreteParamMenuBuilder.h
+++ b/include/sst/jucegui/components/DiscreteParamMenuBuilder.h
@@ -51,10 +51,15 @@ struct DiscreteParamMenuBuilder
      */
     void showMenu(juce::Component *c);
 
-    std::vector<std::pair<int, std::string>> groupList;
+    void setGroupList(const std::vector<std::pair<int, std::string>> &gl) { groupList = gl; }
 
     void populateLinearMenu(juce::PopupMenu &, juce::Component *c);
     void populateGroupListMenu(juce::PopupMenu &, juce::Component *c);
+
+    int jogFromValue(int fromThis, int jog);
+
+  protected:
+    std::vector<std::pair<int, std::string>> groupList;
 };
 
 struct HasDiscreteParamMenuBuilder

--- a/src/sst/jucegui/components/DiscreteParamMenuBuilder.cpp
+++ b/src/sst/jucegui/components/DiscreteParamMenuBuilder.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "sst/jucegui/components/DiscreteParamMenuBuilder.h"
+#include <cassert>
 
 namespace sst::jucegui::components
 {
@@ -99,5 +100,42 @@ void DiscreteParamMenuBuilder::showMenu(juce::Component *c)
     }
 
     p.showMenuAsync(createMenuOptions());
+}
+
+int DiscreteParamMenuBuilder::jogFromValue(int fromThis, int jog)
+{
+    assert(data);
+    switch (mode)
+    {
+    case Mode::LINEAR:
+    {
+        fromThis = fromThis + jog;
+        if (fromThis < data->getMin())
+            fromThis = data->getMax();
+        else if (fromThis > data->getMax())
+            fromThis = data->getMin();
+        return fromThis;
+    }
+    break;
+    case Mode::GROUP_LIST:
+    {
+        // this is forward jog
+        bool returnNext = false;
+        int previous = data->getValue();
+        for (const auto &[id, gn] : groupList)
+        {
+            if (returnNext && jog > 0)
+                return id;
+            if (id == data->getValue())
+            {
+                if (jog < 0)
+                    return previous;
+                returnNext = true;
+            }
+            previous = id;
+        }
+    }
+    }
+    return fromThis;
 }
 } // namespace sst::jucegui::components

--- a/src/sst/jucegui/components/JogUpDownButton.cpp
+++ b/src/sst/jucegui/components/JogUpDownButton.cpp
@@ -106,12 +106,23 @@ void JogUpDownButton::mouseDown(const juce::MouseEvent &e)
 
 void JogUpDownButton::mouseUp(const juce::MouseEvent &e)
 {
+    auto jog = 0;
+    if (e.position.x < getHeight())
+        jog = -1;
+    if (e.position.x > getWidth() - getHeight())
+        jog = 1;
+
     if (data && isEnabled())
     {
-        if (e.position.x < getHeight())
-            data->jog(-1);
-        if (e.position.x > getWidth() - getHeight())
-            data->jog(1);
+        if (popupMenuBuilder)
+        {
+            popupMenuBuilder->setData(data);
+            data->setValueFromGUI(popupMenuBuilder->jogFromValue(data->getValue(), jog));
+        }
+        else
+        {
+            data->jog(jog);
+        }
     }
 }
 } // namespace sst::jucegui::components


### PR DESCRIPTION
The PMB give syou menu order traversals in group list mode. Basically lets you do the surge filter ui properly.