### PR TITLE
HSliderFilled can have skinny paint zone and broad hit zone

### DIFF
--- a/include/sst/jucegui/components/HSliderFilled.h
+++ b/include/sst/jucegui/components/HSliderFilled.h
@@ -27,6 +27,8 @@ struct HSliderFilled : public HSlider
     HSliderFilled();
 
     void paint(juce::Graphics &g) override;
+    int verticalReduction{0}; // if you want the paint zone smaller than the hit zone set this
+    // to pixels to reduce vertically (both sids, so '1' takes 1 off top and bottom)
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(HSliderFilled);
 };

--- a/src/sst/jucegui/components/HSliderFilled.cpp
+++ b/src/sst/jucegui/components/HSliderFilled.cpp
@@ -39,10 +39,10 @@ void HSliderFilled::paint(juce::Graphics &g)
         return;
 
     // Gutter
-    auto b = getLocalBounds();
+    auto b = getLocalBounds().reduced(0, verticalReduction);
     auto o = b.getHeight() - gutterheight;
 
-    auto r = getLocalBounds().toFloat();
+    auto r = getLocalBounds().reduced(0, verticalReduction).toFloat();
     auto rectRad = 5;
 
     if (isHovered)


### PR DESCRIPTION
verticalReduction is a settable member so you can distinguish active zone from paint zone, making up for the lack of a handle hit zone while still keeping a gutter-only look