### PR TITLE
Conditional audio flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ project(sst-jucegui VERSION 0.5 LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-option(SST_JUCEGUI_BUILD_EXAMPLES "Add targets for building and running sst-filters examples" TRUE)
+option(SST_JUCEGUI_BUILD_EXAMPLES "Add targets for building and running sst-filters examples" FALSE)
+option(SST_JUCEGUI_SKIP_AUDIO "Skip JUCE audio definitions" TRUE)
 
 if (${SST_JUCEGUI_BUILD_EXAMPLES})
     if (${PROJECT_IS_TOP_LEVEL})
@@ -128,13 +129,23 @@ else()
     else()
         add_library(sst-jucegui-juce-requirements INTERFACE)
         target_link_libraries(sst-jucegui-juce-requirements INTERFACE juce::juce_gui_basics)
+
         target_compile_definitions(sst-jucegui-juce-requirements INTERFACE
-                JUCE_USE_CURL=0
-                JUCE_WEB_BROWSER=0
+            JUCE_USE_CURL=0
+            JUCE_WEB_BROWSER=0
+        )
+
+        if(NOT ${SST_JUCEGUI_SKIP_AUDIO})
+            target_compile_definitions(sst-jucegui-juce-requirements INTERFACE
                 JUCE_JACK=0
                 JUCE_ALSA=0
                 JUCE_WASAPI=0
-                JUCE_DIRECTSOUND=0)
+                JUCE_DIRECTSOUND=0
+            )
+        else()
+            message(STATUS "SST_JUCEGUI_SKIP_AUDIO is set to FALSE. Audio flags are skipped.")
+        endif()
+
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(sst-jucegui VERSION 0.5 LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-option(SST_JUCEGUI_BUILD_EXAMPLES "Add targets for building and running sst-filters examples" FALSE)
+option(SST_JUCEGUI_BUILD_EXAMPLES "Add targets for building and running sst-filters examples" TRUE)
 
 if (${SST_JUCEGUI_BUILD_EXAMPLES})
     if (${PROJECT_IS_TOP_LEVEL})
@@ -26,7 +26,7 @@ if (${SST_JUCEGUI_BUILD_EXAMPLES})
 
     if (NOT TARGET juce::juce_gui_basics)
         if (NOT DEFINED SST_JUCEGUI_JUCE_VERSION)
-            set(SST_JUCEGUI_JUCE_VERSION 7.0.12)
+            set(SST_JUCEGUI_JUCE_VERSION 8.0.4)
         endif()
         message(STATUS "Downloading JUCE ${SST_JUCEGUI_JUCE_VERSION}")
         set(FETCHCONTENT_QUIET FALSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ else()
                 JUCE_DIRECTSOUND=0
             )
         else()
-            message(STATUS "SST_JUCEGUI_SKIP_AUDIO is set to FALSE. Audio flags are skipped.")
+            message(STATUS "SST_JUCEGUI_SKIP_AUDIO is set to TRUE. Audio flags are skipped.")
         endif()
 
     endif()


### PR DESCRIPTION
- updated juce 7 -> juce 8.0.4 since I'm running osx 15
- new flag `SST_JUCEGUI_SKIP_AUDIO` which can be override downstream to add or to skip the audio flags. 

baconpaul said in discord: 
```
It always zeroes out CURL and WEB_BROWSER. Those have to stay defined
It has an option called "SST_JUCEGUI_SKIP_AUDIO" which defaults to true
if it is true you add those definitions for jack -> directsound
surge sets it to false in lib.cmake before including
```

I think he meant
```It has an option called "SST_JUCEGUI_SKIP_AUDIO" which defaults to true
if it is **FALSE** you add those definitions for jack -> directsound
```

cus  - y'know -

 "skip audio" mean "don't add audio flags" 
NOT "skip audio" means "add flags"
horray for confusing double negatives


but opening it up to discussion. 