### PR TITLE
Accesibility: Discrete Params

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ endif()
 add_library(${PROJECT_NAME} STATIC
         src/sst/jucegui/components/ComponentBase.cpp
         src/sst/jucegui/components/ContinuousParamEditor.cpp
+        src/sst/jucegui/components/DiscreteParamEditor.cpp
         src/sst/jucegui/components/DiscreteParamMenuBuilder.cpp
         src/sst/jucegui/components/DraggableTextEditableValue.cpp
         src/sst/jucegui/components/GlyphButton.cpp

--- a/include/sst/jucegui/components/DiscreteParamMenuBuilder.h
+++ b/include/sst/jucegui/components/DiscreteParamMenuBuilder.h
@@ -27,6 +27,8 @@
 
 namespace sst::jucegui::components
 {
+struct DiscreteParamEditor;
+
 struct DiscreteParamMenuBuilder
 {
     enum struct Mode : uint32_t
@@ -49,12 +51,12 @@ struct DiscreteParamMenuBuilder
      * The component here is used to assume the lifetime fo the data object. As long
      * as component is still in a component hierarchy, data should be valid
      */
-    void showMenu(juce::Component *c);
+    void showMenu(DiscreteParamEditor *c);
 
     void setGroupList(const std::vector<std::pair<int, std::string>> &gl) { groupList = gl; }
 
-    void populateLinearMenu(juce::PopupMenu &, juce::Component *c);
-    void populateGroupListMenu(juce::PopupMenu &, juce::Component *c);
+    void populateLinearMenu(juce::PopupMenu &, DiscreteParamEditor *c);
+    void populateGroupListMenu(juce::PopupMenu &, DiscreteParamEditor *c);
 
     int jogFromValue(int fromThis, int jog);
 

--- a/include/sst/jucegui/components/JogUpDownButton.h
+++ b/include/sst/jucegui/components/JogUpDownButton.h
@@ -65,6 +65,8 @@ struct JogUpDownButton : DiscreteParamEditor,
 
     void paint(juce::Graphics &g) override;
 
+    void showPopup(const juce::ModifierKeys &m) override;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(JogUpDownButton)
 };
 } // namespace sst::jucegui::components

--- a/include/sst/jucegui/components/ToggleButton.h
+++ b/include/sst/jucegui/components/ToggleButton.h
@@ -96,6 +96,13 @@ struct ToggleButton : DiscreteParamEditor,
 
     void paint(juce::Graphics &g) override;
 
+    bool keyPressed(const juce::KeyPress &) override;
+
+    juce::AccessibilityRole getAccessibleRole() const override
+    {
+        return juce::AccessibilityRole::toggleButton;
+    }
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ToggleButton)
 
     bool isPressed{false};

--- a/src/sst/jucegui/components/ContinuousParamEditor.cpp
+++ b/src/sst/jucegui/components/ContinuousParamEditor.cpp
@@ -208,18 +208,21 @@ bool ContinuousParamEditor::keyPressed(const juce::KeyPress &k)
             onBeginEdit();
             continuous()->setValueFromGUI(continuous()->getMax());
             notifyAccessibleChange();
+            repaint();
             onEndEdit();
             return true;
         case act::Action::ToMin:
             onBeginEdit();
             continuous()->setValueFromGUI(continuous()->getMin());
             notifyAccessibleChange();
+            repaint();
             onEndEdit();
             return true;
         case act::Action::ToDefault:
             onBeginEdit();
             continuous()->setValueFromGUI(continuous()->getDefaultValue());
             notifyAccessibleChange();
+            repaint();
             onEndEdit();
             return true;
 
@@ -243,6 +246,7 @@ bool ContinuousParamEditor::keyPressed(const juce::KeyPress &k)
             }
             onBeginEdit();
             continuous()->setValueFromGUI(vn);
+            repaint();
             notifyAccessibleChange();
             onEndEdit();
         }

--- a/src/sst/jucegui/components/DiscreteParamEditor.cpp
+++ b/src/sst/jucegui/components/DiscreteParamEditor.cpp
@@ -1,0 +1,168 @@
+/*
+ * sst-jucegui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-jucegui is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-jucegui available at
+ * https://github.com/surge-synthesizer/sst-jucegui
+ */
+
+#include <sst/jucegui/components/DiscreteParamEditor.h>
+#include <sst/jucegui/components/NamedPanel.h>
+#include <sst/jucegui/components/TypeInOverlay.h>
+#include <algorithm>
+
+namespace sst::jucegui::components
+{
+
+bool DiscreteParamEditor::keyPressed(const juce::KeyPress &k)
+{
+    auto a = this->accessibleEdit(k);
+
+    using act = sst::jucegui::accessibility::AccessibilityKeyboardEditSupport<DiscreteParamEditor>;
+
+    if (!a.isNone())
+    {
+        if (!data)
+            return false;
+        switch (a.action)
+        {
+        case act::Action::ToMax:
+            onBeginEdit();
+            data->setValueFromGUI(data->getMax());
+            repaint();
+            notifyAccessibleChange();
+            onEndEdit();
+            return true;
+        case act::Action::ToMin:
+            onBeginEdit();
+            data->setValueFromGUI(data->getMin());
+            repaint();
+            notifyAccessibleChange();
+            onEndEdit();
+            return true;
+        case act::Action::ToDefault:
+            onBeginEdit();
+            data->setValueFromGUI(data->getDefaultValue());
+            repaint();
+            notifyAccessibleChange();
+            onEndEdit();
+            return true;
+
+        case act::Action::Increase:
+        case act::Action::Decrease:
+        {
+            auto jog = -1;
+            if (a.action == act::Action::Increase)
+            {
+                jog = 1;
+            }
+
+            auto nv = data->getValue() + jog;
+            if (nv > data->getMax())
+                nv = data->getMin();
+            if (nv < data->getMin())
+                nv = data->getMax();
+
+            onBeginEdit();
+            data->setValueFromGUI(nv);
+            repaint();
+            notifyAccessibleChange();
+            onEndEdit();
+        }
+        break;
+        case act::Action::OpenMenu:
+            showPopup(juce::ModifierKeys());
+            break;
+        default:
+            std::cout << __FILE__ << ":" << __LINE__ << " Unused Accessible Action" << std::endl;
+            break;
+        }
+    }
+    return false;
+}
+
+// Accessibility
+struct DiscreteParamEditorAH : public juce::AccessibilityHandler
+{
+    struct DPEValue : public juce::AccessibilityValueInterface
+    {
+        explicit DPEValue(DiscreteParamEditor *s) : slider(s) {}
+
+        DiscreteParamEditor *slider;
+
+        bool isReadOnly() const override { return false; }
+        double getCurrentValue() const override { return slider->data->getValue(); }
+        void setValue(double newValue) override
+        {
+            slider->onBeginEdit();
+            slider->data->setValueFromGUI(newValue);
+            slider->notifyAccessibleChange();
+            slider->repaint();
+            slider->onEndEdit();
+        }
+        juce::String getCurrentValueAsString() const override
+        {
+            return slider->data->getValueAsString();
+        }
+        void setValueAsString(const juce::String &newValue) override
+        {
+            slider->onBeginEdit();
+            slider->data->setValueAsString(newValue.toStdString());
+            slider->notifyAccessibleChange();
+            slider->repaint();
+            slider->onEndEdit();
+        }
+        AccessibleValueRange getRange() const override
+        {
+            return {{(double)slider->data->getMin(), (double)slider->data->getMax()}, 1};
+        }
+
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DPEValue);
+    };
+
+    explicit DiscreteParamEditorAH(DiscreteParamEditor *s)
+        : slider(s),
+          juce::AccessibilityHandler(
+              *s, s->getAccessibleRole(),
+              juce::AccessibilityActions().addAction(juce::AccessibilityActionType::showMenu,
+                                                     [this]() { this->showMenu(); }),
+              AccessibilityHandler::Interfaces{std::make_unique<DPEValue>(s)})
+    {
+    }
+
+    void resetToDefault()
+    {
+        slider->data->setValueFromGUI(slider->data->getDefaultValue());
+        slider->repaint();
+        slider->notifyAccessibleChange();
+    }
+
+    void showMenu() {}
+
+    DiscreteParamEditor *slider;
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DiscreteParamEditorAH);
+};
+
+std::unique_ptr<juce::AccessibilityHandler> DiscreteParamEditor::createAccessibilityHandler()
+{
+    return std::make_unique<DiscreteParamEditorAH>(this);
+}
+
+void DiscreteParamEditor::notifyAccessibleChange()
+{
+    if (auto h = getAccessibilityHandler())
+    {
+        h->notifyAccessibilityEvent(juce::AccessibilityEvent::valueChanged);
+    }
+}
+// end
+} // namespace sst::jucegui::components

--- a/src/sst/jucegui/components/DiscreteParamMenuBuilder.cpp
+++ b/src/sst/jucegui/components/DiscreteParamMenuBuilder.cpp
@@ -16,12 +16,13 @@
  */
 
 #include "sst/jucegui/components/DiscreteParamMenuBuilder.h"
+#include "sst/jucegui/components/DiscreteParamEditor.h"
 #include <cassert>
 
 namespace sst::jucegui::components
 {
 
-void DiscreteParamMenuBuilder::populateLinearMenu(juce::PopupMenu &p, juce::Component *c)
+void DiscreteParamMenuBuilder::populateLinearMenu(juce::PopupMenu &p, DiscreteParamEditor *c)
 {
     auto v = (int)std::round(data->getValue());
     for (auto i = data->getMin(); i <= data->getMax(); ++i)
@@ -31,13 +32,16 @@ void DiscreteParamMenuBuilder::populateLinearMenu(juce::PopupMenu &p, juce::Comp
                   [i, w = juce::Component::SafePointer(c), d = data]() {
                       if (!w)
                           return;
+                      w->onBeginEdit();
                       d->setValueFromGUI(i);
+                      w->notifyAccessibleChange();
                       w->repaint();
+                      w->onEndEdit();
                   });
     }
 }
 
-void DiscreteParamMenuBuilder::populateGroupListMenu(juce::PopupMenu &main, juce::Component *c)
+void DiscreteParamMenuBuilder::populateGroupListMenu(juce::PopupMenu &main, DiscreteParamEditor *c)
 {
     juce::PopupMenu subMenu;
     std::string currGrp;
@@ -71,13 +75,16 @@ void DiscreteParamMenuBuilder::populateGroupListMenu(juce::PopupMenu &main, juce
                      [idv = id, w = juce::Component::SafePointer(c), this]() {
                          if (!w)
                              return;
+                         w->onBeginEdit();
                          data->setValueFromGUI(idv);
+                         w->notifyAccessibleChange();
                          w->repaint();
+                         w->onEndEdit();
                      });
     }
     main.addSubMenu(currGrp, subMenu, true, nullptr, checkSub, 0);
 }
-void DiscreteParamMenuBuilder::showMenu(juce::Component *c)
+void DiscreteParamMenuBuilder::showMenu(DiscreteParamEditor *c)
 {
     auto p = juce::PopupMenu();
 

--- a/src/sst/jucegui/components/JogUpDownButton.cpp
+++ b/src/sst/jucegui/components/JogUpDownButton.cpp
@@ -94,24 +94,29 @@ void JogUpDownButton::mouseDown(const juce::MouseEvent &e)
         (e.mods.isPopupMenu() ||
          (e.position.x > getHeight() && e.position.x < (getWidth() - getHeight()))))
     {
-        if (popupMenuBuilder)
-        {
-            popupMenuBuilder->setData(data);
-            popupMenuBuilder->showMenu(this);
-        }
-        else if (onPopupMenu)
-        {
-            onPopupMenu();
-        }
-        else
-        {
-            DiscreteParamMenuBuilder builder;
-            builder.setData(data);
-            builder.showMenu(this);
-        }
+        showPopup(e.mods);
         return;
     }
     DiscreteParamEditor::mouseDown(e);
+}
+
+void JogUpDownButton::showPopup(const juce::ModifierKeys &m)
+{
+    if (popupMenuBuilder)
+    {
+        popupMenuBuilder->setData(data);
+        popupMenuBuilder->showMenu(this);
+    }
+    else if (onPopupMenu)
+    {
+        onPopupMenu();
+    }
+    else
+    {
+        DiscreteParamMenuBuilder builder;
+        builder.setData(data);
+        builder.showMenu(this);
+    }
 }
 
 void JogUpDownButton::mouseUp(const juce::MouseEvent &e)

--- a/src/sst/jucegui/components/MultiSwitch.cpp
+++ b/src/sst/jucegui/components/MultiSwitch.cpp
@@ -17,6 +17,7 @@
 
 #include <sst/jucegui/components/MultiSwitch.h>
 #include <sst/jucegui/util/DebugHelpers.h>
+#include <sst/jucegui/components/DiscreteParamMenuBuilder.h>
 
 namespace sst::jucegui::components
 {
@@ -156,7 +157,12 @@ void MultiSwitch::setValueFromMouse(const juce::MouseEvent &e)
         val = (int)(e.x / h);
     }
     if (val + data->getMin() != data->getValue())
+    {
+        onBeginEdit();
         data->setValueFromGUI(val + data->getMin());
+        notifyAccessibleChange();
+        onEndEdit();
+    }
 }
 void MultiSwitch::mouseDown(const juce::MouseEvent &e)
 {

--- a/src/sst/jucegui/components/ToggleButton.cpp
+++ b/src/sst/jucegui/components/ToggleButton.cpp
@@ -177,9 +177,26 @@ void ToggleButton::mouseDown(const juce::MouseEvent &e) { onBeginEdit(); }
 void ToggleButton::mouseUp(const juce::MouseEvent &e)
 {
     if (data)
+    {
         data->setValueFromGUI(!data->getValue());
+        notifyAccessibleChange();
+    }
     onEndEdit();
     repaint();
+}
+
+bool ToggleButton::keyPressed(const juce::KeyPress &e)
+{
+    if (e.getKeyCode() == juce::KeyPress::returnKey && data)
+    {
+        onBeginEdit();
+        data->setValueFromGUI(!data->getValue());
+        notifyAccessibleChange();
+        repaint();
+        onEndEdit();
+        return true;
+    }
+    return false;
 }
 
 } // namespace sst::jucegui::components


### PR DESCRIPTION
Implement some rudimentary accesibility for discrete params. This means

1. Most discrete params now get a menu on RMB
2. Repaints, notifies, etc... are all fixed up
3. There's a discrete AH for the components which defaults to slider but which can be overridden for toggle
4. There's a keyboard handler

Immediate improvement in six sines accesibility (and short circuit too once I merge it) but still some work to go