### PR TITLE
Component Tags in JuceGui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,8 @@ add_library(${PROJECT_NAME} STATIC
         src/sst/jucegui/components/ToolTip.cpp
         src/sst/jucegui/components/VSlider.cpp
 
+        src/sst/jucegui/component-adapters/ComponentTags.cpp
+
         src/sst/jucegui/data/TreeTable.cpp
 
         src/sst/jucegui/style/StyleAndSettingsConsumer.cpp

--- a/include/sst/jucegui/component-adapters/ComponentTags.h
+++ b/include/sst/jucegui/component-adapters/ComponentTags.h
@@ -1,0 +1,37 @@
+/*
+ * sst-jucegui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-jucegui is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-jucegui available at
+ * https://github.com/surge-synthesizer/sst-jucegui
+ */
+
+#ifndef INCLUDE_SST_JUCEGUI_COMPONENT_ADAPTERS_COMPONENTTAGS_H
+#define INCLUDE_SST_JUCEGUI_COMPONENT_ADAPTERS_COMPONENTTAGS_H
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <optional>
+
+namespace sst::jucegui::component_adapters
+{
+void setTraversalId(juce::Component *, int64_t);
+std::optional<int64_t> getTraversalId(juce::Component *);
+
+void setFullTraversalId(juce::Component *, int64_t);
+std::optional<int64_t> getFullTraversalId(juce::Component *);
+
+void setClapParamId(juce::Component *, uint32_t);
+std::optional<uint32_t> getClapParamId(juce::Component *);
+
+} // namespace sst::jucegui::component_adapters
+
+#endif // COMPONENTTAGS_H

--- a/src/sst/jucegui/component-adapters/ComponentTags.cpp
+++ b/src/sst/jucegui/component-adapters/ComponentTags.cpp
@@ -1,0 +1,49 @@
+/*
+ * sst-jucegui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-jucegui is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-jucegui available at
+ * https://github.com/surge-synthesizer/sst-jucegui
+ */
+
+#include <sst/jucegui/component-adapters/ComponentTags.h>
+
+namespace sst::jucegui::component_adapters
+{
+
+template <typename CT, typename JT>
+std::optional<CT> unpack(juce::Component *c, const juce::Identifier &id)
+{
+    auto prop = c->getProperties().getVarPointer(id);
+    if (prop)
+    {
+        return static_cast<CT>(static_cast<JT>(*prop));
+    }
+    return std::nullopt;
+}
+
+#define GETSET(name, type, jucetype)                                                               \
+    static juce::Identifier id_##name{"sstjg-" #name};                                             \
+    void set##name(juce::Component *c, type id)                                                    \
+    {                                                                                              \
+        c->getProperties().set(id_##name, (jucetype)id);                                           \
+    }                                                                                              \
+    std::optional<type> get##name(juce::Component *c)                                              \
+    {                                                                                              \
+        return unpack<type, jucetype>(c, id_##name);                                               \
+    }
+
+GETSET(TraversalId, int64_t, juce::int64);
+GETSET(FullTraversalId, int64_t, juce::int64);
+GETSET(ClapParamId, uint32_t, juce::int64);
+
+} // namespace sst::jucegui::component_adapters


### PR DESCRIPTION
Add compoennt tags api. Add ones for clap param, traversal id, and full traversal id. Use these in KeyboardAccesibilityThingy