### PR TITLE
A variety of tooltip timer fixes

### DIFF
--- a/include/sst/jucegui/components/DiscreteParamEditor.h
+++ b/include/sst/jucegui/components/DiscreteParamEditor.h
@@ -120,6 +120,9 @@ struct DiscreteParamEditor
             }
             wheel0 = 0;
         }
+
+        if (onWheelEditOccurred)
+            onWheelEditOccurred();
     }
 
     bool keyPressed(const juce::KeyPress &key) override;

--- a/src/sst/jucegui/components/ComponentBase.cpp
+++ b/src/sst/jucegui/components/ComponentBase.cpp
@@ -37,6 +37,19 @@ struct wiTimer : juce::Timer
                     {
                         w->onIdleHover();
                     }
+                    w->idleActive = true;
+                }
+            }
+            if (w->delayToUnIdleInMs > 0)
+            {
+                w->delayToUnIdleInMs -= WithIdleTimer::idleTimeMS;
+                if (w->delayToUnIdleInMs <= 0 && w->idleActive)
+                {
+                    if (w->onIdleHoverEnd)
+                    {
+                        w->onIdleHoverEnd();
+                    }
+                    w->idleActive = false;
                 }
             }
         }

--- a/src/sst/jucegui/components/ContinuousParamEditor.cpp
+++ b/src/sst/jucegui/components/ContinuousParamEditor.cpp
@@ -188,6 +188,10 @@ void ContinuousParamEditor::mouseWheelMove(const juce::MouseEvent &e,
         notifyAccessibleChange();
     }
     onEndEdit();
+
+    if (onWheelEditOccurred)
+        onWheelEditOccurred();
+
     repaint();
 }
 


### PR DESCRIPTION
A variaety of tooltip timer fixes which led to stuck tooltips and no tooltips on mouse wheel. Basically an API which lets you set up six sines and short circuit properly now