### PR TITLE
Add 'no-unit' api to continuous; use it in draggable text edit

### DIFF
--- a/include/sst/jucegui/components/DraggableTextEditableValue.h
+++ b/include/sst/jucegui/components/DraggableTextEditableValue.h
@@ -71,8 +71,15 @@ struct DraggableTextEditableValue : public juce::Component,
     void setFromEditor();
     void onStyleChanged() override;
 
+    void setDisplayUnits(bool b)
+    {
+        displayUnits = b;
+        repaint();
+    }
+
   private:
     float valueOnMouseDown{0.f};
+    float displayUnits{false};
     std::unique_ptr<juce::TextEditor> underlyingEditor;
 };
 } // namespace sst::jucegui::components

--- a/include/sst/jucegui/data/Continuous.h
+++ b/include/sst/jucegui/data/Continuous.h
@@ -71,6 +71,17 @@ struct Continuous : public Labeled
 
     virtual std::string getValueAsStringFor(float f) const { return std::to_string(f); }
     virtual std::string getValueAsString() const { return getValueAsStringFor(getValue()); }
+
+    // No-units implementation defaults to the regular implementation
+    virtual std::string getValueAsStringWithoutUnitsFor(float f) const
+    {
+        return getValueAsStringFor(f);
+    }
+    virtual std::string getValueAsStringWithoutUnits() const
+    {
+        return getValueAsStringWithoutUnitsFor(getValue());
+    }
+
     virtual void setValueAsString(const std::string &s)
     {
         setValueFromGUI(std::clamp((float)std::atof(s.c_str()), getMin(), getMax()));

--- a/src/sst/jucegui/components/DraggableTextEditableValue.cpp
+++ b/src/sst/jucegui/components/DraggableTextEditableValue.cpp
@@ -68,8 +68,16 @@ void DraggableTextEditableValue::paint(juce::Graphics &g)
         g.setFont(getFont(Styles::labelfont));
         g.setColour(
             getColour(Styles::value)); // on Hover, the text colour is intensionally the same.
-        g.drawText(continuous()->getValueAsString(), getLocalBounds(),
-                   juce::Justification::centred);
+        if (displayUnits)
+        {
+            g.drawText(continuous()->getValueAsString(), getLocalBounds(),
+                       juce::Justification::centred);
+        }
+        else
+        {
+            g.drawText(continuous()->getValueAsStringWithoutUnits(), getLocalBounds(),
+                       juce::Justification::centred);
+        }
     }
 }
 
@@ -96,7 +104,15 @@ void DraggableTextEditableValue::mouseWheelMove(const juce::MouseEvent &event,
 
 void DraggableTextEditableValue::mouseDoubleClick(const juce::MouseEvent &e)
 {
-    underlyingEditor->setText(continuous()->getValueAsString());
+    if (displayUnits)
+    {
+        underlyingEditor->setText(continuous()->getValueAsString());
+    }
+    else
+    {
+        underlyingEditor->setText(continuous()->getValueAsStringWithoutUnits());
+    }
+
     underlyingEditor->setVisible(true);
     underlyingEditor->selectAll();
     underlyingEditor->grabKeyboardFocus();


### PR DESCRIPTION
The units in tight text edit drags were ... the string so add an api so e can skip them, which defaults to the regular string if a continuous doesnt' implement it