### PR TITLE
More CompactPlot factoring

### DIFF
--- a/include/sst/jucegui/data/CompactPlotSource.h
+++ b/include/sst/jucegui/data/CompactPlotSource.h
@@ -1,0 +1,53 @@
+/*
+ * sst-jucegui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-jucegui is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-jucegui available at
+ * https://github.com/surge-synthesizer/sst-jucegui
+ */
+
+#ifndef INCLUDE_SST_JUCEGUI_DATA_COMPACTPLOTSOURCE_H
+#define INCLUDE_SST_JUCEGUI_DATA_COMPACTPLOTSOURCE_H
+
+#include <utility>
+
+#include "WithDataListener.h"
+namespace sst::jucegui::data
+{
+struct CompactPlotSource : public WithDataListener<CompactPlotSource>
+{
+    virtual ~CompactPlotSource()
+    {
+        supressListenerModification = true;
+        for (auto *dl : guilisteners)
+        {
+            dl->sourceVanished(this);
+        }
+        supressListenerModification = false;
+    };
+
+    virtual bool curvePathIsValid() const = 0;
+
+    using point_t = std::pair<float, float>;
+    using plotData_t = std::vector<point_t>;
+    virtual void recalculateCurvePath(plotData_t &into) = 0;
+
+    virtual size_t getSecondaryCurveCount() const { return 0; }
+    virtual void recaculateSecondaryCurvePath(size_t index, plotData_t &into) {}
+
+    using axisBounds_t = std::pair<float, float>;
+    virtual axisBounds_t getXAxisBounds() const { return {0, 1}; }
+    virtual axisBounds_t getYAxisBounds() const { return {-1, 1}; }
+    virtual bool isYAxisFromZero() const { return getYAxisBounds().first == 0; }
+};
+} // namespace sst::jucegui::data
+#endif // COMPACTPLOT_H

--- a/include/sst/jucegui/data/Continuous.h
+++ b/include/sst/jucegui/data/Continuous.h
@@ -25,10 +25,11 @@
 #include <cassert>
 
 #include "Labeled.h"
+#include "WithDataListener.h"
 
 namespace sst::jucegui::data
 {
-struct Continuous : public Labeled
+struct Continuous : public Labeled, WithDataListener<Continuous>
 {
     virtual ~Continuous()
     {
@@ -39,28 +40,6 @@ struct Continuous : public Labeled
         }
         supressListenerModification = false;
     };
-
-    struct DataListener
-    {
-        virtual ~DataListener() = default;
-        // FIXME - in the future we may want this more fine grained
-        virtual void dataChanged() = 0;
-        virtual void sourceVanished(Continuous *) = 0;
-    };
-    bool supressListenerModification{false};
-    void addGUIDataListener(DataListener *l)
-    {
-        assert(!supressListenerModification);
-        if (!supressListenerModification)
-            guilisteners.insert(l);
-    }
-    void removeGUIDataListener(DataListener *l)
-    {
-        if (!supressListenerModification)
-            guilisteners.erase(l);
-    }
-    void addModelDataListener(DataListener *l) { modellisteners.insert(l); }
-    void removeModelDataListener(DataListener *l) { modellisteners.erase(l); }
 
     virtual float getValue() const = 0;
     virtual void setValueFromGUI(const float &f) = 0;
@@ -100,9 +79,6 @@ struct Continuous : public Labeled
         float qval = std::clamp(qs * (int)std::round(val / qs), getMin(), getMax());
         return qval;
     }
-
-  protected:
-    std::unordered_set<DataListener *> guilisteners, modellisteners;
 };
 
 struct ContinuousModulatable : public Continuous

--- a/include/sst/jucegui/data/Discrete.h
+++ b/include/sst/jucegui/data/Discrete.h
@@ -24,10 +24,11 @@
 #include <string>
 #include <algorithm>
 #include "Labeled.h"
+#include "WithDataListener.h"
 
 namespace sst::jucegui::data
 {
-struct Discrete : public Labeled
+struct Discrete : public Labeled, WithDataListener<Discrete>
 {
     virtual ~Discrete()
     {
@@ -38,23 +39,6 @@ struct Discrete : public Labeled
         }
         supressListenerModification = false;
     }
-
-    struct DataListener
-    {
-        virtual ~DataListener() = default;
-        // FIXME - in the future we may want this more fine grained
-        virtual void dataChanged() = 0;
-        virtual void sourceVanished(Discrete *) = 0;
-    };
-    bool supressListenerModification{false};
-    void addGUIDataListener(DataListener *l) { guilisteners.insert(l); }
-    void removeGUIDataListener(DataListener *l)
-    {
-        if (!supressListenerModification)
-            guilisteners.erase(l);
-    }
-    void addModelDataListener(DataListener *l) { modellisteners.insert(l); }
-    void removeModelDataListener(DataListener *l) { modellisteners.erase(l); }
 
     virtual int getValue() const = 0;
     virtual int getDefaultValue() const { return getMin(); }
@@ -87,9 +71,6 @@ struct Discrete : public Labeled
         }
         setValueFromGUI(v);
     }
-
-  protected:
-    std::unordered_set<DataListener *> guilisteners, modellisteners;
 };
 
 struct BinaryDiscrete : public Discrete

--- a/include/sst/jucegui/data/WithDataListener.h
+++ b/include/sst/jucegui/data/WithDataListener.h
@@ -1,0 +1,55 @@
+/*
+ * sst-jucegui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-jucegui is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-jucegui available at
+ * https://github.com/surge-synthesizer/sst-jucegui
+ */
+
+#ifndef INCLUDE_SST_JUCEGUI_DATA_WITHDATALISTENER_H
+#define INCLUDE_SST_JUCEGUI_DATA_WITHDATALISTENER_H
+
+#include <cassert>
+#include <unordered_set>
+
+namespace sst::jucegui::data
+{
+template <typename T> struct WithDataListener
+{
+
+    struct DataListener
+    {
+        virtual ~DataListener() = default;
+        // FIXME - in the future we may want this more fine grained
+        virtual void dataChanged() = 0;
+        virtual void sourceVanished(T *) = 0;
+    };
+    bool supressListenerModification{false};
+    void addGUIDataListener(DataListener *l)
+    {
+        assert(!supressListenerModification);
+        if (!supressListenerModification)
+            guilisteners.insert(l);
+    }
+    void removeGUIDataListener(DataListener *l)
+    {
+        if (!supressListenerModification)
+            guilisteners.erase(l);
+    }
+    void addModelDataListener(DataListener *l) { modellisteners.insert(l); }
+    void removeModelDataListener(DataListener *l) { modellisteners.erase(l); }
+
+  protected:
+    std::unordered_set<DataListener *> guilisteners, modellisteners;
+};
+} // namespace sst::jucegui::data
+#endif // WITHDATALISTENER_H

--- a/src/sst/jucegui/components/CompactPlot.cpp
+++ b/src/sst/jucegui/components/CompactPlot.cpp
@@ -21,17 +21,22 @@ namespace sst::jucegui::components
 {
 void CompactPlot::paint(juce::Graphics &g)
 {
-    auto cl = 1.0f;
-    if (!isYAxisFromZero())
+    if (!source)
     {
-        auto yb = getYAxisBounds();
+        g.fillAll(juce::Colours::red);
+        return;
+    }
+    auto cl = 1.0f;
+    if (!source->isYAxisFromZero())
+    {
+        auto yb = source->getYAxisBounds();
         cl = yb.second / (-yb.first + yb.second);
     }
 
-    if (curvePath.isEmpty() || plotData.empty() || !curvePathIsValid())
+    if (curvePath.isEmpty() || plotData.empty() || !source->curvePathIsValid())
     {
         plotData.clear();
-        recalculateCurvePath(plotData);
+        source->recalculateCurvePath(plotData);
 
         curvePath.clear();
         positiveCurvePath.clear();


### PR DESCRIPTION
1. Source separate from Renderer, like the rest of the kit
2. Make the has data listener lifecycle loop thingy a base class to avoid a third copy; normalize continuous and discrete cases to use it also