### PR TITLE
Fix an order-of-deletion problem which made a windows crash

### DIFF
--- a/src/sst/jucegui/components/ListView.cpp
+++ b/src/sst/jucegui/components/ListView.cpp
@@ -125,7 +125,7 @@ void ListView::rowSelected(uint32_t r, bool b, SelectionAddAction addMode)
         {
             for (auto &rs : innards->selectedRows)
             {
-                if (rs != r)
+                if (rs != r && rs >= 0 && rs < size(innards->components))
                 {
                     setRowSelection(innards->components[rs], false);
                 }


### PR DESCRIPTION
basically the onCB can still use the imte so yield the UI thread when visibility change detected before delete