### PR TITLE
Fix two api points in the Rescaler

### DIFF
--- a/include/sst/jucegui/component-adapters/ThrowRescaler.h
+++ b/include/sst/jucegui/component-adapters/ThrowRescaler.h
@@ -89,7 +89,10 @@ struct ThrowRescalerBase : data::Continuous, data::WithDataListener<data::Contin
 template <typename T> struct CubicThrowRescaler : ThrowRescalerBase<T>
 {
     // This assumes min = -max or min = 0
-    CubicThrowRescaler(std::unique_ptr<T> u) : ThrowRescalerBase<T>(std::move(u)) { assertSymmetry(); }
+    CubicThrowRescaler(std::unique_ptr<T> u) : ThrowRescalerBase<T>(std::move(u))
+    {
+        assertSymmetry();
+    }
 
     CubicThrowRescaler(T *u) : ThrowRescalerBase<T>(u) { assertSymmetry(); }
 


### PR DESCRIPTION
In 2cf92a748693537410277c8cb99a5fa6cbc1568b I ported the rescaler from six sines into the jucegui library but never actualy rebuilt six sines with it. This fixes two omissions which arose when I ported and used it elsewhere which stopped six sines from working.