### PR TITLE
Fix a warning from juce::Font() being deprecated

### DIFF
--- a/src/sst/jucegui/style/StyleSheet.cpp
+++ b/src/sst/jucegui/style/StyleSheet.cpp
@@ -103,16 +103,7 @@ struct StyleSheetBuiltInImpl : public StyleSheet
     {
         jassert(isValidPair(c, p));
 
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#endif
-
-        fonts[c.cname][p.pname] = f;
-
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
+        fonts[c.cname].insert_or_assign(p.pname, f);
     }
 
     void replaceFontsWithTypeface(const juce::Typeface::Ptr &p) override


### PR DESCRIPTION
making it painful to use in containers