### PR TITLE
Add a 'label-source' / 'labelSource' member to JSON layout

### DIFF
--- a/include/sst/jucegui/layouts/JsonLayoutEngine.h
+++ b/include/sst/jucegui/layouts/JsonLayoutEngine.h
@@ -133,6 +133,9 @@ struct Control
     Position position;
     std::optional<std::string> fixedValue;
     std::optional<std::string> label;
+    // Declarative: consumers may interpret "short"/"name" to choose where label text comes from.
+    // The engine never reads this; it's resolved by the host (e.g. ProcessorPane).
+    std::optional<std::string> labelSource;
 
     std::unordered_map<std::string, std::string> extraKVs;
 

--- a/src/sst/jucegui/layouts/JsonLayoutEngine.cpp
+++ b/src/sst/jucegui/layouts/JsonLayoutEngine.cpp
@@ -253,6 +253,10 @@ JsonLayoutEngine::retval_t JsonLayoutEngine::parseSingleControl(juce::DynamicObj
     {
         c.label = controlObj->getProperty("label").toString().toStdString();
     }
+    if (controlObj->hasProperty("label-source"))
+    {
+        c.labelSource = controlObj->getProperty("label-source").toString().toStdString();
+    }
 
     // Process control binding
     if (controlObj->hasProperty("binding"))
@@ -380,7 +384,7 @@ JsonLayoutEngine::retval_t JsonLayoutEngine::parseSingleControl(juce::DynamicObj
 
     /* Capture all unprocessed string-valued properties into extraKVs */
     static const std::set<std::string> handledControlProperties = {
-        "class",      "label",    "binding",      "enabled-if",
+        "class",      "label",    "label-source", "binding",    "enabled-if",
         "visible-if", "position", "line-segment", "fixed-value"};
     for (const auto &prop : controlObj->getProperties())
     {


### PR DESCRIPTION
Which rather than label is intended to be interpreted by the parent as a place where the label originates. In short circuit we use 'short' and 'name' to mean pmd.shortName and pmd.name but you can use whatever you want!