### PR TITLE
DiscreteMenuBuilder ordering bug

### DIFF
--- a/src/sst/jucegui/components/DiscreteParamMenuBuilder.cpp
+++ b/src/sst/jucegui/components/DiscreteParamMenuBuilder.cpp
@@ -52,8 +52,6 @@ void DiscreteParamMenuBuilder::populateGroupListMenu(juce::PopupMenu &main, Disc
     bool checkSub{false};
     for (const auto &[id, gn] : groupList)
     {
-        if (id == v)
-            checkSub = true;
         if (gn != currGrp)
         {
             if (!currGrp.empty())
@@ -64,6 +62,10 @@ void DiscreteParamMenuBuilder::populateGroupListMenu(juce::PopupMenu &main, Disc
             }
             currGrp = gn;
         }
+        // Set the parent check after flushing the prior group, so the tick lands
+        // on the group the selected item actually belongs to.
+        if (id == v)
+            checkSub = true;
         auto tgt = &subMenu;
         if (gn.empty())
         {


### PR DESCRIPTION
We checked group-change at the wrong flush point for submenus so group menus woul dcheck prior group for member 1 of any group.

Assisted-By: Claude Opus 4.8