### PR TITLE
Allow style driven control of knob and gutter

### DIFF
--- a/include/sst/jucegui/components/HSlider.h
+++ b/include/sst/jucegui/components/HSlider.h
@@ -37,9 +37,6 @@ struct HSlider : public ContinuousParamEditor, public style::StyleConsumer
         }
     };
 
-    static constexpr int hanRadius = 7;
-    static constexpr int gutterheight = 4;
-
     HSlider();
     ~HSlider();
 

--- a/include/sst/jucegui/components/VSlider.h
+++ b/include/sst/jucegui/components/VSlider.h
@@ -37,9 +37,6 @@ struct VSlider : public ContinuousParamEditor, public style::StyleConsumer
         }
     };
 
-    static constexpr int hanRadius = 7;
-    static constexpr int gutterwidth = 8;
-
     VSlider();
     ~VSlider();
 

--- a/include/sst/jucegui/style/StyleSheet.h
+++ b/include/sst/jucegui/style/StyleSheet.h
@@ -167,6 +167,31 @@ struct StyleSheet
     virtual void setFontHeightDelta(float delta) = 0;
     virtual void setFontExtraKerningFactor(float fac) = 0;
 
+    virtual int getSliderGutterWidth() const { return sliderGutterWidth; }
+    virtual int getSliderHandleRadius() const { return sliderHandleRadius; }
+    virtual int getKnobRingStrokeWidth(int forWidth) const
+    {
+        return forWidth < knobRingStrokeThreshold ? knobRingStrokeNarrow : knobRingStrokeWide;
+    }
+
+    virtual void setSliderGutterWidth(int w) { sliderGutterWidth = w; }
+    virtual void setSliderHandleRadius(int r) { sliderHandleRadius = r; }
+    // wide stroke at/above threshold, narrow below it
+    virtual void setKnobRingStrokeWidth(int wide, int narrow, int threshold)
+    {
+        knobRingStrokeWide = wide;
+        knobRingStrokeNarrow = narrow;
+        knobRingStrokeThreshold = threshold;
+    }
+
+  protected:
+    int sliderGutterWidth{8};
+    int sliderHandleRadius{7};
+    int knobRingStrokeWide{5};
+    int knobRingStrokeNarrow{3};
+    int knobRingStrokeThreshold{21}; // width < 21 (i.e. <= 20) uses the narrow stroke
+
+  public:
     typedef std::shared_ptr<StyleSheet> ptr_t;
 
     enum BuiltInTypes

--- a/src/sst/jucegui/components/HSlider.cpp
+++ b/src/sst/jucegui/components/HSlider.cpp
@@ -39,6 +39,9 @@ void HSlider::paint(juce::Graphics &g)
     if (continuous()->isHidden())
         return;
 
+    auto gutterheight = style()->getSliderGutterWidth();
+    auto hanRadius = style()->getSliderHandleRadius();
+
     bool vCenter = !showLabel && !showValue;
 
     if (showLabel)

--- a/src/sst/jucegui/components/HSliderFilled.cpp
+++ b/src/sst/jucegui/components/HSliderFilled.cpp
@@ -38,10 +38,6 @@ void HSliderFilled::paint(juce::Graphics &g)
     if (continuous()->isHidden())
         return;
 
-    // Gutter
-    auto b = getLocalBounds().reduced(0, verticalReduction);
-    auto o = b.getHeight() - gutterheight;
-
     auto r = getLocalBounds().reduced(0, verticalReduction).toFloat();
     auto rectRad = 5;
 
@@ -102,7 +98,6 @@ void HSliderFilled::paint(juce::Graphics &g)
         auto hm = (1.0 - mvplus) * gutter.getWidth();
         mpc =
             gutter.withTrimmedLeft(gutter.getWidth() - hm).withWidth(1).expanded(0, 4).getCentre();
-        mpr = juce::Rectangle<float>(2 * hanRadius, 2 * hanRadius).withCentre(mpc);
 
         // draw rules
         {

--- a/src/sst/jucegui/components/KnobPainter.hxx
+++ b/src/sst/jucegui/components/KnobPainter.hxx
@@ -18,9 +18,7 @@ template <typename T, typename S> void knobPainterNoBody(juce::Graphics &g, T *t
     auto b = that->getLocalBounds();
     auto knobarea = b.withHeight(b.getWidth());
 
-    int strokeWidth{5};
-    if (knobarea.getWidth() < 20)
-        strokeWidth = 3;
+    int strokeWidth = that->style()->getKnobRingStrokeWidth(knobarea.getWidth());
 
     //  start and end here are 0...1
     auto arcFromTo = [knobarea, strokeWidth](float startV, float endV) {
@@ -163,13 +161,8 @@ template <typename T, typename S> void knobPainter(juce::Graphics &g, T *that, S
     auto kbcol = that->getColour(T::Styles::knobbase);
     knobPainterNoBody(g, that, source);
 
-    int strokeWidth{5};
-    bool smallKnob = false;
-    if (knobarea.getWidth() < 20)
-    {
-        smallKnob = true;
-        strokeWidth = 3;
-    }
+    int strokeWidth = that->style()->getKnobRingStrokeWidth(knobarea.getWidth());
+    bool smallKnob = knobarea.getWidth() < 20;
 
     auto circle = [knobarea](float r) -> juce::Path {
         auto region = knobarea.toFloat().reduced(r);

--- a/src/sst/jucegui/components/VSlider.cpp
+++ b/src/sst/jucegui/components/VSlider.cpp
@@ -36,6 +36,9 @@ void VSlider::paint(juce::Graphics &g)
     if (continuous()->isHidden())
         return;
 
+    auto gutterwidth = style()->getSliderGutterWidth();
+    auto hanRadius = style()->getSliderHandleRadius();
+
     // Gutter
     auto b = getLocalBounds();
     auto o = b.getWidth() - gutterwidth;


### PR DESCRIPTION
Knob ring and gutter width for v/hsliders is now style sheet controllable