### PR TITLE
Allow modal screens to dismiss on escape and commit on return

### DIFF
--- a/include/sst/jucegui/screens/AlertOrPrompt.h
+++ b/include/sst/jucegui/screens/AlertOrPrompt.h
@@ -73,6 +73,8 @@ struct AlertOrPrompt : ModalBase
 
     void prepare()
     {
+        processKeys = true;
+
         if (title.has_value())
         {
             titleL = std::make_unique<components::Label>();
@@ -129,6 +131,23 @@ struct AlertOrPrompt : ModalBase
     void mouseDown(const juce::MouseEvent &event) override
     {
         if (!onOK && !onCancel)
+            setVisible(false);
+    }
+
+    // escape is cancel (or no), and never fires the OK action
+    void onEscape() override
+    {
+        if (onCancel)
+            onCancel();
+        if (isVisible())
+            setVisible(false);
+    }
+
+    void onReturn() override
+    {
+        if (onOK)
+            onOK();
+        if (isVisible())
             setVisible(false);
     }
 

--- a/include/sst/jucegui/screens/ModalBase.h
+++ b/include/sst/jucegui/screens/ModalBase.h
@@ -51,6 +51,43 @@ struct ModalBase : juce::Component, style::StyleConsumer
     virtual void paintContents(juce::Graphics &g) {}
     virtual juce::Point<int> innerContentSize() = 0; // w,h
 
+    // Opt in to escape/return handling. A subclass which sets this takes keyboard
+    // focus while visible and should override onEscape/onReturn.
+    bool processKeys{false};
+    // When processing keys, also swallow the ones we don't handle, so host key
+    // bindings don't fire underneath the modal.
+    bool consumesAllKeys{false};
+
+    virtual void onEscape() {}
+    virtual void onReturn() {}
+
+    void visibilityChanged() override
+    {
+        setWantsKeyboardFocus(processKeys);
+        if (isVisible() && processKeys)
+            grabKeyboardFocus();
+    }
+
+    bool keyPressed(const juce::KeyPress &key) override
+    {
+        if (!processKeys)
+            return false;
+
+        if (key.getKeyCode() == juce::KeyPress::escapeKey)
+        {
+            onEscape();
+            return true;
+        }
+
+        if (key.getKeyCode() == juce::KeyPress::returnKey)
+        {
+            onReturn();
+            return true;
+        }
+
+        return consumesAllKeys;
+    }
+
     juce::Rectangle<int> getContentArea()
     {
         auto sz = innerContentSize();

--- a/include/sst/jucegui/screens/PromptForValue.h
+++ b/include/sst/jucegui/screens/PromptForValue.h
@@ -50,6 +50,8 @@ struct PromptForValue : ModalBase
     void prepare()
     {
         prepared = true;
+        processKeys = true;
+
         if (title.has_value())
         {
             titleL = std::make_unique<components::Label>();
@@ -128,8 +130,13 @@ struct PromptForValue : ModalBase
         }
     }
 
+    // if focus is on a button rather than the editor, esc/return still commit
+    void onEscape() override { commitCancel(); }
+    void onReturn() override { commitOK(); }
+
     void visibilityChanged() override
     {
+        ModalBase::visibilityChanged();
         if (isVisible() && editor)
         {
             editor->grabKeyboardFocus();


### PR DESCRIPTION
ModalBase gains an opt-in processKeys flag with onEscape/onReturn hooks, so a modal only takes keyboard focus and handles keys if it asks to. AlertOrPrompt and PromptForValue opt in, mapping escape to cancel and return to OK.

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>