### PR TITLE
Add a draggable text value for discrete parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ add_library(${PROJECT_NAME} STATIC
         src/sst/jucegui/components/DiscreteParamEditor.cpp
         src/sst/jucegui/components/DiscreteParamMenuBuilder.cpp
         src/sst/jucegui/components/DraggableTextEditableValue.cpp
+        src/sst/jucegui/components/DraggableTextEditableDiscreteValue.cpp
         src/sst/jucegui/components/GlyphButton.cpp
         src/sst/jucegui/components/GlyphPainter.cpp
         src/sst/jucegui/components/HSlider.cpp

--- a/include/sst/jucegui/components/DiscreteParamEditor.h
+++ b/include/sst/jucegui/components/DiscreteParamEditor.h
@@ -58,7 +58,7 @@ struct DiscreteParamEditor
         assert(d == data);
         setSource(nullptr);
     }
-    void setSource(data::Discrete *d)
+    virtual void setSource(data::Discrete *d)
     {
         if (data)
             data->removeGUIDataListener(this);
@@ -132,6 +132,10 @@ struct DiscreteParamEditor
         if (onPopupMenu)
             onPopupMenu(m);
     }
+
+    // Hook for the accessible "open editor" keyboard action; overridden by
+    // editable discrete widgets (e.g. the draggable text value) to open type-in.
+    virtual void openTypeInEditor() {}
 
     data::Discrete *data{nullptr};
 

--- a/include/sst/jucegui/components/DraggableTextEditableDiscreteValue.h
+++ b/include/sst/jucegui/components/DraggableTextEditableDiscreteValue.h
@@ -1,0 +1,122 @@
+/*
+ * sst-jucegui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-jucegui is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-jucegui available at
+ * https://github.com/surge-synthesizer/sst-jucegui
+ */
+
+#ifndef INCLUDE_SST_JUCEGUI_COMPONENTS_DRAGGABLETEXTEDITABLEDISCRETEVALUE_H
+#define INCLUDE_SST_JUCEGUI_COMPONENTS_DRAGGABLETEXTEDITABLEDISCRETEVALUE_H
+
+#include <string>
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <sst/jucegui/style/StyleAndSettingsConsumer.h>
+#include <sst/jucegui/style/StyleSheet.h>
+#include <sst/jucegui/components/BaseStyles.h>
+#include <sst/jucegui/components/DiscreteParamEditor.h>
+#include <sst/jucegui/components/TextEditableValueSupport.h>
+
+namespace sst::jucegui::components
+{
+
+/*
+ * A draggable, type-in text value for discrete (integer-backed) parameters. It
+ * is the discrete-model sibling of DraggableTextEditableValue: the wheel and
+ * arrow keys jog by whole steps for free from DiscreteParamEditor, drag jogs on
+ * fixed pixels, and right-click / double-click / keyboard open inline type-in.
+ */
+struct DraggableTextEditableDiscreteValue
+    : public DiscreteParamEditor,
+      public style::StyleConsumer,
+      public TextEditableValueSupport<DraggableTextEditableDiscreteValue>
+{
+    // Same style class as the continuous draggable text value, so a theme that
+    // colours one colours both.
+    using Styles = TextEditableValueSupport<DraggableTextEditableDiscreteValue>::Styles;
+
+    DraggableTextEditableDiscreteValue();
+    ~DraggableTextEditableDiscreteValue() override;
+
+    void paint(juce::Graphics &g) override;
+    void resized() override;
+
+    void mouseDown(const juce::MouseEvent &e) override;
+    void mouseUp(const juce::MouseEvent &e) override;
+    void mouseDrag(const juce::MouseEvent &e) override;
+    void mouseDoubleClick(const juce::MouseEvent &e) override;
+
+    void onStyleChanged() override;
+
+    // keyboard "open editor" action from DiscreteParamEditor
+    void openTypeInEditor() override { activateEditor(); }
+
+    /*
+     * A numeric text value is an ordered range, so wheel/keyboard must not wrap
+     * past the end. This is set here rather than on the attachment because the
+     * same discrete attachments also drive enumerable widgets (menus, switches),
+     * where wrapping is the desired behaviour.
+     */
+    void setSource(data::Discrete *d) override
+    {
+        DiscreteParamEditor::setSource(d);
+        if (d)
+            d->setJogWrapsAtEnd(false);
+    }
+
+    void setDisplayUnits(bool b)
+    {
+        displayUnits = b;
+        repaint();
+    }
+
+    // hooks required by TextEditableValueSupport
+    bool hasSource() { return data != nullptr; }
+    std::string displayString()
+    {
+        if (!data)
+            return "";
+        return displayUnits ? data->getValueAsString() : data->getValueAsStringWithoutUnits();
+    }
+    void applyString(const std::string &s)
+    {
+        if (data)
+            data->setValueAsString(s);
+    }
+    void applyDefault()
+    {
+        if (data)
+            data->setValueFromGUI(data->getDefaultValue());
+    }
+
+    // Pixels of vertical drag per single jog. Per-platform starting values;
+    // calibrate by feel once landed. Uses JUCE's platform macros (not the
+    // target-private JUCEGUI_* ones, which are invisible to header consumers).
+#if JUCE_WINDOWS
+    static constexpr int pixelsPerJog{3};
+#elif JUCE_LINUX
+    static constexpr int pixelsPerJog{3};
+#else
+    static constexpr int pixelsPerJog{3};
+#endif
+    // shift widens the pixels-per-jog and switches to a single raw step, so a
+    // stepped param still gets fine positioning where one jog is more than 1.
+    static constexpr int shiftJogFactor{10};
+
+  protected:
+    int dragStepsEmitted{0};
+};
+} // namespace sst::jucegui::components
+
+#endif // INCLUDE_SST_JUCEGUI_COMPONENTS_DRAGGABLETEXTEDITABLEDISCRETEVALUE_H

--- a/include/sst/jucegui/components/DraggableTextEditableValue.h
+++ b/include/sst/jucegui/components/DraggableTextEditableValue.h
@@ -26,29 +26,18 @@
 #include <sst/jucegui/style/StyleSheet.h>
 #include <sst/jucegui/components/BaseStyles.h>
 #include <sst/jucegui/components/ContinuousParamEditor.h>
+#include <sst/jucegui/components/TextEditableValueSupport.h>
 
 #include "ComponentBase.h"
 
 namespace sst::jucegui::components
 {
 
-struct DraggableTextEditableValue : public ContinuousParamEditor, public style::StyleConsumer
+struct DraggableTextEditableValue : public ContinuousParamEditor,
+                                    public style::StyleConsumer,
+                                    public TextEditableValueSupport<DraggableTextEditableValue>
 {
-    struct Styles : base_styles::Base,
-                    base_styles::Outlined,
-                    base_styles::BaseLabel,
-                    base_styles::ValueBearing
-    {
-        SCLASS(draggabletexteditor);
-        static void initialize()
-        {
-            style::StyleSheet::addClass(styleClass)
-                .withBaseClass(base_styles::Base::styleClass)
-                .withBaseClass(base_styles::Outlined::styleClass)
-                .withBaseClass(base_styles::BaseLabel::styleClass)
-                .withBaseClass(base_styles::ValueBearing::styleClass);
-        }
-    };
+    using Styles = TextEditableValueSupport<DraggableTextEditableValue>::Styles;
 
     DraggableTextEditableValue();
     ~DraggableTextEditableValue() override;
@@ -65,7 +54,6 @@ struct DraggableTextEditableValue : public ContinuousParamEditor, public style::
 
     void mouseDoubleClick(const juce::MouseEvent &e) override;
 
-    void setFromEditor();
     void onStyleChanged() override;
 
     void setDisplayUnits(bool b)
@@ -74,9 +62,15 @@ struct DraggableTextEditableValue : public ContinuousParamEditor, public style::
         repaint();
     }
 
-    void activateEditor();
-
-    bool isSetFromDrag() const { return isEditDrag; }
+    // hooks required by TextEditableValueSupport
+    bool hasSource() { return continuous() != nullptr; }
+    std::string displayString()
+    {
+        return displayUnits ? continuous()->getValueAsString()
+                            : continuous()->getValueAsStringWithoutUnits();
+    }
+    void applyString(const std::string &s) { continuous()->setValueAsString(s); }
+    void applyDefault() { continuous()->setValueFromGUI(continuous()->getDefaultValue()); }
 
     float dragScale{0.5f}, dragShiftRatio{0.1f};
     void setDragScaleFromMinMaxHeuristic()
@@ -95,17 +89,6 @@ struct DraggableTextEditableValue : public ContinuousParamEditor, public style::
 
   protected:
     float valueOnMouseDown{0.f};
-    float displayUnits{false};
-    bool everDragged{false};
-    std::unique_ptr<juce::TextEditor> underlyingEditor;
-
-    bool isEditDrag{false};
-    struct EditIsDragGuard
-    {
-        DraggableTextEditableValue &w;
-        EditIsDragGuard(DraggableTextEditableValue &w) : w(w) { w.isEditDrag = true; }
-        ~EditIsDragGuard() { w.isEditDrag = false; }
-    };
 };
 } // namespace sst::jucegui::components
 

--- a/include/sst/jucegui/components/TextEditableValueSupport.h
+++ b/include/sst/jucegui/components/TextEditableValueSupport.h
@@ -1,0 +1,239 @@
+/*
+ * sst-jucegui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-jucegui is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-jucegui available at
+ * https://github.com/surge-synthesizer/sst-jucegui
+ */
+
+#ifndef INCLUDE_SST_JUCEGUI_COMPONENTS_TEXTEDITABLEVALUESUPPORT_H
+#define INCLUDE_SST_JUCEGUI_COMPONENTS_TEXTEDITABLEVALUESUPPORT_H
+
+#include <memory>
+#include <string>
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <sst/jucegui/style/StyleSheet.h>
+#include <sst/jucegui/components/BaseStyles.h>
+
+namespace sst::jucegui::components
+{
+
+// A text editor whose ctrl+return submits a plain return, so a multi-field
+// container can distinguish the two. Shared by the draggable text value widgets.
+struct TextEditableValueEditor : juce::TextEditor
+{
+    TextEditableValueEditor() : TextEditor() {}
+    bool keyPressed(const juce::KeyPress &key) override
+    {
+        if (key.getModifiers().isCtrlDown() && (key.getKeyCode() == juce::KeyPress::returnKey))
+        {
+            auto kp = juce::KeyPress(juce::KeyPress::returnKey);
+            return juce::TextEditor::keyPressed(kp);
+        }
+        return juce::TextEditor::keyPressed(key);
+    }
+};
+
+/*
+ * Style class shared by the continuous and discrete draggable text values.
+ * Deliberately declared outside the CRTP template below: SCLASS expands to a
+ * static constexpr object, so putting it inside the template would mint one
+ * styleClass per instantiation and the two widgets would theme independently
+ * despite carrying the same name.
+ */
+struct TextEditableValueStyles : base_styles::Base,
+                                 base_styles::Outlined,
+                                 base_styles::BaseLabel,
+                                 base_styles::ValueBearing
+{
+    SCLASS(draggabletexteditor);
+    static void initialize()
+    {
+        style::StyleSheet::addClass(styleClass)
+            .withBaseClass(base_styles::Base::styleClass)
+            .withBaseClass(base_styles::Outlined::styleClass)
+            .withBaseClass(base_styles::BaseLabel::styleClass)
+            .withBaseClass(base_styles::ValueBearing::styleClass);
+    }
+};
+
+/*
+ * Shared implementation for the draggable text value widgets. Mixed into a
+ * concrete widget T, which must be a juce::Component and a style::StyleConsumer,
+ * and must supply:
+ *
+ *   bool hasSource();                         // is a data source bound
+ *   std::string displayString();              // value text, honouring displayUnits
+ *   void applyString(const std::string &s);   // commit typed text
+ *   void applyDefault();                       // commit on empty string
+ *
+ * The paint/mouse helpers take `that` explicitly rather than using asT() so a
+ * *subclass* of T can reuse them and still resolve style and callbacks against
+ * itself -- that is what lets a widget which overrides paint() (e.g. to draw a
+ * split n/d display) reuse the background and value-text drawing.
+ *
+ * Because the continuous and discrete param editors are unrelated CRTP base
+ * classes, sharing is by mixin rather than by a common base.
+ */
+template <typename T> struct TextEditableValueSupport
+{
+    using Styles = TextEditableValueStyles;
+
+    std::unique_ptr<juce::TextEditor> underlyingEditor;
+    bool displayUnits{false};
+    bool everDragged{false};
+    bool isEditDrag{false};
+
+    bool isSetFromDrag() const { return isEditDrag; }
+
+    struct EditIsDragGuard
+    {
+        TextEditableValueSupport<T> &w;
+        EditIsDragGuard(TextEditableValueSupport<T> &w) : w(w) { w.isEditDrag = true; }
+        ~EditIsDragGuard() { w.isEditDrag = false; }
+    };
+
+    T *asT() { return static_cast<T *>(this); }
+
+    void initTextEditor()
+    {
+        auto self = asT();
+        underlyingEditor = std::make_unique<TextEditableValueEditor>();
+        underlyingEditor->onEscapeKey = [sp = juce::Component::SafePointer(self)] {
+            if (sp)
+                sp->underlyingEditor->setVisible(false);
+        };
+        underlyingEditor->onFocusLost = [sp = juce::Component::SafePointer(self)] {
+            if (sp && sp->underlyingEditor->isVisible())
+                sp->setFromEditor();
+        };
+        underlyingEditor->onReturnKey = [sp = juce::Component::SafePointer(self)] {
+            if (sp)
+                sp->setFromEditor();
+        };
+        self->addChildComponent(*underlyingEditor);
+    }
+
+    void activateEditor()
+    {
+        auto self = asT();
+        underlyingEditor->setText(self->displayString());
+        underlyingEditor->setVisible(true);
+        underlyingEditor->selectAll();
+        underlyingEditor->grabKeyboardFocus();
+    }
+
+    void setFromEditor()
+    {
+        auto self = asT();
+        jassert(underlyingEditor->isVisible());
+        auto t = underlyingEditor->getText();
+        if (t.isEmpty())
+            self->applyDefault();
+        else
+            self->applyString(t.toStdString());
+        underlyingEditor->setVisible(false);
+        self->repaint();
+    }
+
+    void restyleTextEditor(const juce::Font &font)
+    {
+        underlyingEditor->setColour(juce::TextEditor::ColourIds::outlineColourId,
+                                    juce::Colours::black.withAlpha(0.f));
+        underlyingEditor->setColour(juce::TextEditor::ColourIds::focusedOutlineColourId,
+                                    juce::Colours::black.withAlpha(0.f));
+        underlyingEditor->setColour(juce::TextEditor::ColourIds::backgroundColourId,
+                                    juce::Colours::black.withAlpha(0.f));
+        underlyingEditor->setFont(font);
+        underlyingEditor->setIndents(0, 0);
+        underlyingEditor->setJustification(juce::Justification::centred);
+    }
+
+    void layoutTextEditor(juce::Rectangle<int> b) { underlyingEditor->setBounds(b); }
+
+    template <typename W>
+    void paintBackgroundFor(W *that, juce::Graphics &g, juce::Rectangle<int> area)
+    {
+        g.setColour(that->getColour(Styles::background));
+        if (that->isHovered)
+            g.setColour(that->getColour(Styles::background_hover));
+        g.fillRoundedRectangle(area.toFloat(), 3.f);
+    }
+
+    template <typename W> void paintBackgroundFor(W *that, juce::Graphics &g)
+    {
+        paintBackgroundFor(that, g, that->getLocalBounds());
+    }
+
+    template <typename W>
+    void paintValueTextFor(W *that, juce::Graphics &g, const std::string &text,
+                           juce::Rectangle<int> area)
+    {
+        g.setFont(that->getFont(Styles::labelfont));
+        // on hover the text colour is intentionally the same
+        auto col = that->getColour(Styles::value);
+        g.setColour(that->isEnabled() ? col : col.withAlpha(0.5f));
+        g.drawText(text, area, juce::Justification::centred);
+    }
+
+    // background plus the centred value, suppressed while the type-in is open
+    template <typename W> void paintFor(W *that, juce::Graphics &g)
+    {
+        paintBackgroundFor(that, g);
+        if (that->hasSource() && !underlyingEditor->isVisible())
+            paintValueTextFor(that, g, that->displayString(), that->getLocalBounds());
+    }
+
+    /*
+     * Mouse. Only the shared prologue lives here; the drag body is the one thing
+     * each widget genuinely does differently (float delta from an anchor vs
+     * residual pixels to whole jogs), so it stays in the widget. Each returns
+     * false when the caller should stop -- i.e. the event was a popup.
+     */
+    template <typename W> bool mouseDownFor(W *that, const juce::MouseEvent &e)
+    {
+        if (e.mods.isPopupMenu() && that->onPopupMenu)
+        {
+            that->onPopupMenu(e.mods);
+            return false;
+        }
+        everDragged = false;
+        return true;
+    }
+
+    template <typename W> void mouseUpFor(W *that, const juce::MouseEvent &e)
+    {
+        if (e.mods.isPopupMenu() && that->onPopupMenu)
+            return;
+
+        if (everDragged)
+            that->onEndEdit();
+        else
+            activateEditor();
+    }
+
+    template <typename W> bool mouseDragFor(W *that, const juce::MouseEvent &e)
+    {
+        if (e.mods.isPopupMenu() && that->onPopupMenu)
+            return false;
+        if (!everDragged)
+            that->onBeginEdit();
+        everDragged = true;
+        return true;
+    }
+};
+
+} // namespace sst::jucegui::components
+
+#endif // INCLUDE_SST_JUCEGUI_COMPONENTS_TEXTEDITABLEVALUESUPPORT_H

--- a/include/sst/jucegui/data/Discrete.h
+++ b/include/sst/jucegui/data/Discrete.h
@@ -22,6 +22,7 @@
 #include <unordered_set>
 #include <vector>
 #include <string>
+#include <optional>
 #include <algorithm>
 #include "Labeled.h"
 #include "WithDataListener.h"
@@ -52,10 +53,34 @@ struct Discrete : public Labeled, WithDataListener<Discrete>
 
     virtual std::string getValueAsStringFor(int i) const { return std::to_string(i); }
     virtual std::string getValueAsString() const { return getValueAsStringFor(getValue()); }
+
+    // No-units implementation defaults to the regular implementation, matching
+    // the Continuous contract so a text-editable widget can suppress units while
+    // the value is being typed.
+    virtual std::string getValueAsStringWithoutUnitsFor(int i) const
+    {
+        return getValueAsStringFor(i);
+    }
+    virtual std::string getValueAsStringWithoutUnits() const
+    {
+        return getValueAsStringWithoutUnitsFor(getValue());
+    }
+    virtual std::optional<std::string> getValueAlternateAsStringFor(int) const
+    {
+        return std::nullopt;
+    }
+    virtual std::optional<std::string> getValueAlternateAsString() const
+    {
+        return getValueAlternateAsStringFor(getValue());
+    }
+
     virtual void setValueAsString(const std::string &s) { setValueFromGUI(std::atof(s.c_str())); }
 
     virtual int getMin() const { return 0; }
     virtual int getMax() const { return 1; }
+
+    // How many discrete steps a "quantized" (cmd/coarse) jog should move.
+    virtual int getQuantizedStepSize() const { return 1; }
 
     virtual bool isBipolar() const { return getMin() == -getMax(); }
 

--- a/src/sst/jucegui/components/DiscreteParamEditor.cpp
+++ b/src/sst/jucegui/components/DiscreteParamEditor.cpp
@@ -60,26 +60,25 @@ bool DiscreteParamEditor::keyPressed(const juce::KeyPress &k)
         case act::Action::Increase:
         case act::Action::Decrease:
         {
-            auto jog = -1;
-            if (a.action == act::Action::Increase)
-            {
-                jog = 1;
-            }
-
-            auto nv = data->getValue() + jog;
-            if (nv > data->getMax())
-                nv = data->getMin();
-            if (nv < data->getMin())
-                nv = data->getMax();
+            // Jog through the data model so jogWrapsAtEnd and any coarse-jog
+            // override (e.g. sample-point increments) are honoured, rather than
+            // hardcoding a ±1 wrap here.
+            auto dir = a.action == act::Action::Increase ? 1 : -1;
+            if (a.mod == act::Action::Quantized)
+                dir *= data->getQuantizedStepSize();
 
             onBeginEdit();
-            data->setValueFromGUI(nv);
+            data->jog(dir);
             repaint();
             notifyAccessibleChange();
             onEndEdit();
             return true;
         }
         break;
+        case act::Action::OpenEditor:
+            openTypeInEditor();
+            return true;
+            break;
         case act::Action::OpenMenu:
             showPopup(juce::ModifierKeys());
             return true;

--- a/src/sst/jucegui/components/DraggableTextEditableDiscreteValue.cpp
+++ b/src/sst/jucegui/components/DraggableTextEditableDiscreteValue.cpp
@@ -1,0 +1,94 @@
+/*
+ * sst-jucegui - an open source library of juce widgets
+ * built by Surge Synth Team.
+ *
+ * Copyright 2023-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-jucegui is released under the MIT license, as described
+ * by "LICENSE.md" in this repository. This means you may use this
+ * in commercial software if you are a JUCE Licensee. If you use JUCE
+ * in the open source / GPL3 context, your combined work must be
+ * released under GPL3.
+ *
+ * All source in sst-jucegui available at
+ * https://github.com/surge-synthesizer/sst-jucegui
+ */
+
+#include <algorithm>
+
+#include <sst/jucegui/components/DraggableTextEditableDiscreteValue.h>
+
+namespace sst::jucegui::components
+{
+
+DraggableTextEditableDiscreteValue::DraggableTextEditableDiscreteValue()
+    : style::StyleConsumer(Styles::styleClass)
+{
+    initTextEditor();
+}
+
+DraggableTextEditableDiscreteValue::~DraggableTextEditableDiscreteValue() = default;
+
+void DraggableTextEditableDiscreteValue::paint(juce::Graphics &g) { paintFor(this, g); }
+
+void DraggableTextEditableDiscreteValue::mouseDown(const juce::MouseEvent &e)
+{
+    if (!mouseDownFor(this, e))
+        return;
+
+    dragStepsEmitted = 0;
+}
+
+void DraggableTextEditableDiscreteValue::mouseUp(const juce::MouseEvent &e)
+{
+    mouseUpFor(this, e);
+    dragStepsEmitted = 0;
+}
+
+void DraggableTextEditableDiscreteValue::mouseDrag(const juce::MouseEvent &e)
+{
+    if (!data)
+        return;
+    if (!mouseDragFor(this, e))
+        return;
+
+    // Accumulate raw drag pixels and emit one jog per pixelsPerJog crossed. The
+    // residual lives in the (cumulative) drag distance itself, so no value is
+    // cached across events: each jog reads the model fresh.
+    auto d = e.getDistanceFromDragStartY();
+    bool fine = e.mods.isShiftDown();
+    auto pxPer = fine ? pixelsPerJog * shiftJogFactor : pixelsPerJog;
+    int wantSteps = (int)((float)(-d) / (float)pxPer);
+    int delta = wantSteps - dragStepsEmitted;
+    if (delta != 0)
+    {
+        auto eidg = EditIsDragGuard(*this);
+        if (fine)
+        {
+            // one raw unit per step, bypassing any coarse jog() increment
+            auto nv = std::clamp(data->getValue() + delta, data->getMin(), data->getMax());
+            data->setValueFromGUI(nv);
+        }
+        else
+        {
+            data->jog(delta);
+        }
+        dragStepsEmitted = wantSteps;
+        notifyAccessibleChange();
+    }
+    repaint();
+}
+
+void DraggableTextEditableDiscreteValue::mouseDoubleClick(const juce::MouseEvent &e)
+{
+    activateEditor();
+}
+
+void DraggableTextEditableDiscreteValue::onStyleChanged()
+{
+    restyleTextEditor(getFont(Styles::labelfont));
+}
+
+void DraggableTextEditableDiscreteValue::resized() { layoutTextEditor(getLocalBounds()); }
+} // namespace sst::jucegui::components

--- a/src/sst/jucegui/components/DraggableTextEditableValue.cpp
+++ b/src/sst/jucegui/components/DraggableTextEditableValue.cpp
@@ -21,137 +21,30 @@
 namespace sst::jucegui::components
 {
 
-struct DraggableTextEditorCustomTextEditor : juce::TextEditor
-{
-    DraggableTextEditorCustomTextEditor() : TextEditor() {}
-    bool keyPressed(const juce::KeyPress &key) override
-    {
-        if (key.getModifiers().isCtrlDown() && (key.getKeyCode() == juce::KeyPress::returnKey))
-        {
-            auto kp = juce::KeyPress(juce::KeyPress::returnKey);
-            return juce::TextEditor::keyPressed(kp);
-        }
-        else
-        {
-            return juce::TextEditor::keyPressed(key);
-        }
-    }
-};
-
 DraggableTextEditableValue::DraggableTextEditableValue()
     : ContinuousParamEditor(Direction::VERTICAL), style::StyleConsumer(Styles::styleClass)
 {
-    underlyingEditor = std::make_unique<DraggableTextEditorCustomTextEditor>();
-
-    underlyingEditor->onEscapeKey = [sp = juce::Component::SafePointer(this)] {
-        if (sp)
-            sp->underlyingEditor->setVisible(false);
-    };
-    underlyingEditor->onFocusLost = [sp = juce::Component::SafePointer(this)] {
-        if (sp && sp->underlyingEditor->isVisible())
-            sp->setFromEditor();
-    };
-    underlyingEditor->onReturnKey = [sp = juce::Component::SafePointer(this)] {
-        if (sp)
-            sp->setFromEditor();
-    };
-
-    addChildComponent(*underlyingEditor);
+    initTextEditor();
 }
 
 DraggableTextEditableValue::~DraggableTextEditableValue() = default;
 
-void DraggableTextEditableValue::setFromEditor()
-{
-    jassert(underlyingEditor->isVisible());
-
-    auto t = underlyingEditor->getText();
-    if (t.isEmpty())
-    {
-        continuous()->setValueFromGUI(continuous()->getDefaultValue());
-    }
-    else
-    {
-        continuous()->setValueAsString(t.toStdString());
-    }
-    underlyingEditor->setVisible(false);
-    repaint();
-}
-
-void DraggableTextEditableValue::paint(juce::Graphics &g)
-{
-    g.setColour(getColour(Styles::background));
-    if (isHovered)
-        g.setColour(getColour(Styles::background_hover));
-    g.fillRoundedRectangle(getLocalBounds().toFloat(), 3.f);
-
-    if (continuous() && !underlyingEditor->isVisible())
-    {
-        g.setFont(getFont(Styles::labelfont));
-        if (isEnabled())
-        {
-            g.setColour(
-                getColour(Styles::value)); // on Hover, the text colour is intensionally the same.
-        }
-        else
-        {
-            g.setColour(getColour(Styles::value).withAlpha(0.5f));
-        }
-        if (displayUnits)
-        {
-            g.drawText(continuous()->getValueAsString(), getLocalBounds(),
-                       juce::Justification::centred);
-        }
-        else
-        {
-            g.drawText(continuous()->getValueAsStringWithoutUnits(), getLocalBounds(),
-                       juce::Justification::centred);
-        }
-    }
-}
+void DraggableTextEditableValue::paint(juce::Graphics &g) { paintFor(this, g); }
 
 void DraggableTextEditableValue::mouseDown(const juce::MouseEvent &e)
 {
-    if (e.mods.isPopupMenu() && onPopupMenu)
-    {
-        onPopupMenu(e.mods);
+    if (!mouseDownFor(this, e))
         return;
-    }
 
-    everDragged = false;
     valueOnMouseDown = continuous()->getValue();
 }
-void DraggableTextEditableValue::mouseUp(const juce::MouseEvent &e)
-{
-    if (e.mods.isPopupMenu() && onPopupMenu)
-    {
-        return;
-    }
-
-    if (everDragged)
-    {
-        onEndEdit();
-    }
-    else
-    {
-        activateEditor();
-    }
-}
+void DraggableTextEditableValue::mouseUp(const juce::MouseEvent &e) { mouseUpFor(this, e); }
 void DraggableTextEditableValue::mouseDrag(const juce::MouseEvent &e)
 {
-    if (e.mods.isPopupMenu() && onPopupMenu)
-    {
+    if (!mouseDragFor(this, e))
         return;
-    }
 
     auto d = e.getDistanceFromDragStartY();
-    if (!everDragged)
-    {
-        onBeginEdit();
-    }
-
-    everDragged = true;
-
     auto fac = dragScale * (e.mods.isShiftDown() ? dragShiftRatio : 1.f);
     auto nv = valueOnMouseDown - fac * d * continuous()->getMinMaxRange() * 0.01f;
     nv = std::clamp(nv, continuous()->getMin(), continuous()->getMax());
@@ -166,33 +59,7 @@ void DraggableTextEditableValue::mouseDrag(const juce::MouseEvent &e)
 }
 
 void DraggableTextEditableValue::mouseDoubleClick(const juce::MouseEvent &e) { activateEditor(); }
-void DraggableTextEditableValue::activateEditor()
-{
-    if (displayUnits)
-    {
-        underlyingEditor->setText(continuous()->getValueAsString());
-    }
-    else
-    {
-        underlyingEditor->setText(continuous()->getValueAsStringWithoutUnits());
-    }
 
-    underlyingEditor->setVisible(true);
-    underlyingEditor->selectAll();
-    underlyingEditor->grabKeyboardFocus();
-}
-
-void DraggableTextEditableValue::onStyleChanged()
-{
-    underlyingEditor->setColour(juce::TextEditor::ColourIds::outlineColourId,
-                                juce::Colours::black.withAlpha(0.f));
-    underlyingEditor->setColour(juce::TextEditor::ColourIds::focusedOutlineColourId,
-                                juce::Colours::black.withAlpha(0.f));
-    underlyingEditor->setColour(juce::TextEditor::ColourIds::backgroundColourId,
-                                juce::Colours::black.withAlpha(0.f));
-    underlyingEditor->setFont(getFont(Styles::labelfont));
-    underlyingEditor->setIndents(0, 0);
-    underlyingEditor->setJustification(juce::Justification::centred);
-}
-void DraggableTextEditableValue::resized() { underlyingEditor->setBounds(getLocalBounds()); }
+void DraggableTextEditableValue::onStyleChanged() { restyleTextEditor(getFont(Styles::labelfont)); }
+void DraggableTextEditableValue::resized() { layoutTextEditor(getLocalBounds()); }
 } // namespace sst::jucegui::components


### PR DESCRIPTION
Integer parameters have only ever had the continuous draggable text value, which truncates on write. The wheel and arrow keys therefore skip values and travel further down than up, and drag speed scales with the parameter range so it differs wildly between controls.

Add DraggableTextEditableDiscreteValue, which sits on the discrete data model so the wheel and arrow keys move in whole steps and one drag step is a fixed number of pixels. Shift widens the pixels per step and drops to a single unit, so parameters with a coarse jog still position finely.

Give data::Discrete the string handling it was missing - units-free and alternate display, and a quantized step size - so a text widget can render and parse through the parameter metadata rather than integers.

Share the type-in editor, painting and mouse prologue between the two draggable text values through TextEditableValueSupport, including the style class, so a theme colours both and a subclass overriding paint can still reuse the standard drawing.

Also make the keyboard honour jogWrapsAtEnd instead of always wrapping, and let a discrete editor open its type-in from the keyboard.

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>